### PR TITLE
Add "Set adrift astronaut" action

### DIFF
--- a/modules/php/Game.php
+++ b/modules/php/Game.php
@@ -352,9 +352,12 @@ class Game extends \Table
 
     function actSetAdrift(string $cardDrawn, string $cardSetAdrift)
     {
-
         $current_player_id = (int) $this->getCurrentPlayerId();
-        $this->cards->moveCard($cardDrawn, 'hand', $current_player_id);
+        if ($cardDrawn == 'deck') {
+            $this->cards->pickCard('deck', $current_player_id);
+        } else {
+            $this->cards->moveCard($cardDrawn, 'hand', $current_player_id);
+        }
         $this->cards->moveCard($cardSetAdrift, 'adrift');
 
         // $this->gamestate->nextState('finishSettingAdrift');

--- a/modules/php/Game.php
+++ b/modules/php/Game.php
@@ -180,9 +180,18 @@ class Game extends \Table
 
         $this->activeNextPlayer();
 
-        // Go to another gamestate
-        // Here, we would detect if the game is over, and in this case use "endGame" transition instead 
-        $this->gamestate->nextState("nextPlayer");
+        $this->gamestate->nextState('goToNextPlayerTurn');
+    }
+
+    public function stDrawAtEndOfTurn(): void
+    {
+        $player_id = (int)$this->getActivePlayerId();
+        $hand = $this->cards->getCardsInLocation('hand', $player_id);
+        if (count($hand) < 6) {
+            $this->cards->pickCardForLocation('deck', 'hand', $player_id);
+        }
+
+        $this->gamestate->nextState('nextPlayer');
     }
 
     /**
@@ -360,8 +369,7 @@ class Game extends \Table
         }
         $this->cards->moveCard($cardSetAdrift, 'adrift');
 
-        // $this->gamestate->nextState('finishSettingAdrift');
-        // TODO: goto end of turn -> drawing a card
+        $this->gamestate->nextState('drawAtEndOfTurn');
     }
 
     /**

--- a/modules/php/Game.php
+++ b/modules/php/Game.php
@@ -238,7 +238,7 @@ class Game extends \Table
 
         // TODO: Gather all information about current game situation (visible by player $current_player_id).
         $result['adrift'] = $this->getCollectionFromDB(
-            "SELECT card_type_arg cardNum
+            "SELECT card_id id, card_type_arg cardNum
             FROM card 
             WHERE card_location = 'adrift'"
         );
@@ -348,6 +348,17 @@ class Game extends \Table
         foreach ($players as $player_id => $player) {
             $this->cards->pickCardsForLocation(5, 'deck', 'hand', $player_id);
         }
+    }
+
+    function actSetAdrift(string $cardDrawn, string $cardSetAdrift)
+    {
+
+        $current_player_id = (int) $this->getCurrentPlayerId();
+        $this->cards->moveCard($cardDrawn, 'hand', $current_player_id);
+        $this->cards->moveCard($cardSetAdrift, 'adrift');
+
+        // $this->gamestate->nextState('finishSettingAdrift');
+        // TODO: goto end of turn -> drawing a card
     }
 
     /**

--- a/source/client/build/gamestates.d.ts
+++ b/source/client/build/gamestates.d.ts
@@ -29,7 +29,16 @@ interface DefinedGameStates extends ValidateGameStates<{
 		'possibleactions': ['connectAstronauts', 'actSetAdrift'],
 		'transitions': {
 			'finishConnectingAstronauts': 30,
-			'finishSettingAdrift': 30,
+			'drawAtEndOfTurn': 25,
+		},
+	},
+	25: {
+		'name': 'drawAtEndOfTurn',
+		'description': '${actplayer} draws a card if they have fewer than 6 cards in hand',
+		'type': 'game',
+		'action': 'stDrawAtEndOfTurn',
+		'transitions': {
+			'nextPlayer': 30,
 		},
 	},
 	30: {

--- a/source/client/build/gamestates.d.ts
+++ b/source/client/build/gamestates.d.ts
@@ -26,21 +26,21 @@ interface DefinedGameStates extends ValidateGameStates<{
 		'description': '${actplayer} must connect astronauts or set an astronaut adrift',
 		'descriptionmyturn': '${you} must connect astronauts or set an astronaut adrift',
 		'type': 'activeplayer',
-		'possibleactions': ['connectAstronauts', 'setAdrift'],
+		'possibleactions': ['connectAstronauts', 'actSetAdrift'],
 		'transitions': {
-			'connectAstronauts': 20,
-			'setAdrift': 20,
+			'finishConnectingAstronauts': 30,
+			'finishSettingAdrift': 30,
 		},
 	},
-	20: {
+	30: {
 		'name': 'nextPlayer',
 		'description': '',
 		'type': 'game',
 		'action': 'stNextPlayer',
 		'updateGameProgression': true,
 		'transitions': {
-			'endGame': 99,
-			'nextPlayer': 10,
+			'goToGameEnd': 99,
+			'goToNextPlayerTurn': 10,
 		},
 	},
 	99: {
@@ -56,7 +56,10 @@ interface GameStateArgs {}
 
 interface GameStatePossibleActions {
 	'connectAstronauts': {},
-	'setAdrift': {},
+	'actSetAdrift': {
+		'cardDrawn': string,
+		'cardSetAdrift': string,
+	},
 }
 
 }

--- a/source/client/build/gamestates.d.ts
+++ b/source/client/build/gamestates.d.ts
@@ -18,18 +18,29 @@ interface DefinedGameStates extends ValidateGameStates<{
 		'type': 'manager',
 		'action': 'stGameSetup',
 		'transitions': {
-			'': 2,
+			'': 10,
 		},
 	},
-	2: {
-		'name': 'dummmy',
-		'description': '${actplayer} must play a card or pass',
-		'descriptionmyturn': '${you} must play a card or pass',
+	10: {
+		'name': 'playerTurn',
+		'description': '${actplayer} must connect astronauts or set an astronaut adrift',
+		'descriptionmyturn': '${you} must connect astronauts or set an astronaut adrift',
 		'type': 'activeplayer',
-		'possibleactions': ['playCard', 'pass'],
+		'possibleactions': ['connectAstronauts', 'setAdrift'],
 		'transitions': {
-			'playCard': 2,
-			'pass': 2,
+			'connectAstronauts': 20,
+			'setAdrift': 20,
+		},
+	},
+	20: {
+		'name': 'nextPlayer',
+		'description': '',
+		'type': 'game',
+		'action': 'stNextPlayer',
+		'updateGameProgression': true,
+		'transitions': {
+			'endGame': 99,
+			'nextPlayer': 10,
 		},
 	},
 	99: {
@@ -44,10 +55,8 @@ interface DefinedGameStates extends ValidateGameStates<{
 interface GameStateArgs {}
 
 interface GameStatePossibleActions {
-	'playCard': {
-		'card_id': number,
-	},
-	'pass': {},
+	'connectAstronauts': {},
+	'setAdrift': {},
 }
 
 }

--- a/source/client/tethergame.d.ts
+++ b/source/client/tethergame.d.ts
@@ -11,7 +11,8 @@ declare namespace BGA {
   /** Goto {@link Gamedatas} or hover name for info. */
   interface Gamedatas extends Record<string, any> {
     adrift: {
-      [cardNum: string]: {
+      [cardId: string]: {
+        id: string;
         cardNum: string;
       };
     };

--- a/source/client/tethergame.d.ts
+++ b/source/client/tethergame.d.ts
@@ -11,12 +11,12 @@ declare namespace BGA {
   /** Goto {@link Gamedatas} or hover name for info. */
   interface Gamedatas extends Record<string, any> {
     adrift: {
-      [cardNum: number]: {
+      [cardNum: string]: {
         cardNum: string;
       };
     };
     hand: {
-      [cardId: number]: {
+      [cardId: string]: {
         id: string;
         type: string;
         type_arg: string;

--- a/source/client/tethergame.scss
+++ b/source/client/tethergame.scss
@@ -71,4 +71,13 @@
   &--adrift {
     transform: rotate(90deg);
   }
+
+  &--selectable {
+    outline: 0.1rem dashed black;
+    cursor: pointer;
+  }
+
+  &--selected {
+    outline: 0.25rem solid yellowgreen;
+  }
 }

--- a/source/client/tethergame.scss
+++ b/source/client/tethergame.scss
@@ -59,6 +59,16 @@
   border: 1px dashed darkseagreen;
 }
 
+.deck {
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 5px;
+  margin: 5px;
+  width: 75px;
+  height: 105px;
+  background-color: steelblue;
+}
+
 .card {
   border: 1px solid black;
   border-radius: 5px;

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -320,56 +320,7 @@ class TetherGame extends Gamegui {
         });
       }
     });
-    // when clicked, store the id and move to the next client state
-    // in the next client state, the player can choose to draw from the adrift zone or deck
-    // then send everything to server and update
   }
-
-  /* Example:
-
-	onButtonClicked( evt: Event )
-	{
-		console.log( 'onButtonClicked' );
-
-		// Preventing default browser reaction
-		evt.preventDefault();
-
-		// Builtin example...
-		if(this.checkAction( 'myAction' ))
-		{
-			this.ajaxcall(
-				`/${this.game_name!}/${this.game_name!}/myAction.html`,
-				{
-					lock: true, 
-					myArgument1: arg1,
-					myArgument2: arg2,
-				},
-				this,
-				function( server_response: unknown ) {
-					// Callback only on success (no error)
-					// (for player actions, this is almost always empty)
-				}, function(error: boolean, errorMessage?: string, errorCode?: number) {
-					// What to do after the server call in anyway (success or failure)
-					// (usually catch unexpected server errors)
-				},
-			);
-		}
-
-		// Builtin example with new BGA wrapper...
-		this.bgaPerformAction( 'myAction', { myArgument1: arg1, myArgument2: arg2 } );
-
-		//	With CommonMixin from 'cookbook/common'...
-		this.ajaxAction(
-			'myAction',
-			{ myArgument1: arg1, myArgument2: arg2 },
-			function(error: boolean, errorMessage?: string, errorCode?: number) {
-				// What to do after the server call in anyway (success or failure)
-				// (usually catch unexpected server errors)
-			}
-		);
-	}
-
-	*/
 
   ///////////////////////////////////////////////////
   //// Reaction to cometD notifications

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -27,8 +27,6 @@ class TetherGame extends Gamegui {
     handler: EventListener;
   }[] = [];
 
-  // TODO: check if it's worthwhile to make this every possible card number, i.e.
-  // one of the 53 cards. Can we use template literal type?
   cardSetAdrift: string | null = null;
 
   /** See {@link BGA.Gamegui} for more information. */
@@ -59,11 +57,13 @@ class TetherGame extends Gamegui {
     hand.id = 'hand';
     gamePlayArea.appendChild(hand);
 
-    for (const cardNum in gamedatas.adrift) {
+    for (const cardId in gamedatas.adrift) {
       const cardElement = document.createElement('div');
       cardElement.classList.add('card');
       cardElement.classList.add('card--adrift');
       cardElement.classList.add('js-adrift');
+      cardElement.dataset['cardId'] = cardId;
+      const cardNum = gamedatas.adrift[cardId]!.cardNum;
       cardElement.dataset['cardNumber'] = cardNum;
       cardElement.innerText = cardNum;
       adriftZone.appendChild(cardElement);
@@ -71,6 +71,7 @@ class TetherGame extends Gamegui {
 
     for (const cardId in gamedatas.hand) {
       const cardElement = document.createElement('div');
+      cardElement.dataset['cardId'] = cardId;
       const cardNumber = gamedatas.hand[cardId]!.type_arg;
       cardElement.dataset['cardNumber'] = cardNumber;
       cardElement.innerText = cardNumber;
@@ -152,6 +153,7 @@ class TetherGame extends Gamegui {
           false,
           'red'
         );
+        break;
       // @ts-expect-error
       case 'client_setAdriftChooseDraw':
         this.addActionButton(
@@ -161,6 +163,7 @@ class TetherGame extends Gamegui {
             this.drawFromDeck(e);
           }
         );
+        break;
     }
   }
 
@@ -219,7 +222,7 @@ class TetherGame extends Gamegui {
     }
     e.target.classList.add('card--selected');
 
-    this.cardSetAdrift = e.target.dataset['cardNumber']!;
+    this.cardSetAdrift = e.target.dataset['cardId']!;
     this.clearSelectableCards();
 
     for (const handler of this.eventHandlers) {
@@ -255,14 +258,19 @@ class TetherGame extends Gamegui {
     e.preventDefault();
     e.stopPropagation();
 
-    if (!e.target.dataset['cardNumber'] || !this.cardSetAdrift) {
-      throw new Error('cardNumber or cardSetAdrift not set properly');
+    if (!e.target.dataset['cardId'] || !this.cardSetAdrift) {
+      throw new Error('id of card to draw or cardSetAdrift not set properly');
     }
     this.clearSelectableCards();
     this.clearSelectedCards();
 
-    this.bgaPerformAction('setAdrift', {
-      cardDrawn: e.target.dataset['cardNumber'],
+    const cardDrawn = e.target.dataset['cardId'];
+    const cardSetAdrift = this.cardSetAdrift;
+
+    console.table({ cardDrawn, cardSetAdrift });
+
+    this.bgaPerformAction('actSetAdrift', {
+      cardDrawn: e.target.dataset['cardId'],
       cardSetAdrift: this.cardSetAdrift,
     });
 

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -78,7 +78,7 @@ class TetherGame extends Gamegui {
     console.log('Entering state: ' + stateName);
 
     switch (stateName) {
-      case 'dummmy':
+      default:
         // enable/disable any user interaction...
         break;
     }
@@ -89,7 +89,7 @@ class TetherGame extends Gamegui {
     console.log('Leaving state: ' + stateName);
 
     switch (stateName) {
-      case 'dummmy':
+      default:
         // enable/disable any user interaction...
         break;
     }
@@ -104,7 +104,7 @@ class TetherGame extends Gamegui {
     if (!this.isCurrentPlayerActive()) return;
 
     switch (stateName) {
-      case 'dummmy':
+      default:
         // Add buttons to action bar...
         // this.addActionButton( 'button_id', _('Button label'), this.onButtonClicked );
         break;

--- a/source/shared/gamestates.jsonc
+++ b/source/shared/gamestates.jsonc
@@ -46,8 +46,16 @@
     },
     "transitions": {
       "finishConnectingAstronauts": 30,
-      "finishSettingAdrift": 30
+      "drawAtEndOfTurn": 25
     }
+  },
+
+  "25": {
+    "name": "drawAtEndOfTurn",
+    "description": "${actplayer} draws a card if they have fewer than 6 cards in hand",
+    "type": "game",
+    "action": "stDrawAtEndOfTurn",
+    "transitions": { "nextPlayer": 30 }
   },
 
   "30": {

--- a/source/shared/gamestates.jsonc
+++ b/source/shared/gamestates.jsonc
@@ -15,60 +15,46 @@
  * !! It is not a good idea to modify this file when a game is running !!
  */
 {
-	"$schema": "../../node_modules/bga-ts-template/schema/gamestates.schema.json",
+  "$schema": "../../node_modules/bga-ts-template/schema/gamestates.schema.json",
 
-	// The initial state. Please do not modify.
-	"1": {
-		"name": "gameSetup",
-		"description": "",
-		"type": "manager",
-		"action": "stGameSetup",
-		"transitions": { "": 2 }
-	},
+  // The initial state. Please do not modify.
+  "1": {
+    "name": "gameSetup",
+    "description": "",
+    "type": "manager",
+    "action": "stGameSetup",
+    "transitions": { "": 10 }
+  },
 
-	// Note: ID=2: your first state. If not, change the transition in the gameSetup above.
-	"2": {
-		"name": "dummmy",
-		"description": "${actplayer} must play a card or pass",
-		"descriptionmyturn": "${you} must play a card or pass",
-		"type": "activeplayer",
-		"possibleactions": {
-			"playCard": [{ "name": "card_id", "type": "AT_int" }],
-			"pass": []
-		},
-		"transitions": { "playCard": 2, "pass": 2 }
-	},
+  "10": {
+    "name": "playerTurn",
+    "description": "${actplayer} must connect astronauts or set an astronaut adrift",
+    "descriptionmyturn": "${you} must connect astronauts or set an astronaut adrift",
+    "type": "activeplayer",
+    "possibleactions": {
+      "connectAstronauts": [],
+      "setAdrift": []
+    },
+    "transitions": { "connectAstronauts": 20, "setAdrift": 20 }
+  },
 
-/*
-	// Examples:
-	
-	"2": {
-		"name": "nextPlayer",
-		"description": "",
-		"type": "game",
-		"action": "stNextPlayer",
-		"updateGameProgression": true,
-		"transitions": { "endGame": 99, "nextPlayer": 10 }
-	},
+  "20": {
+    "name": "nextPlayer",
+    "description": "",
+    "type": "game",
+    "action": "stNextPlayer",
+    "updateGameProgression": true,
+    "transitions": { "endGame": 99, "nextPlayer": 10 }
+  },
 
-	"10": {
-		"name": "playerTurn",
-		"description": "${actplayer} must play a card or pass",
-		"descriptionmyturn": "${you} must play a card or pass",
-		"type": "activeplayer",
-		"possibleactions": [ "playCard", "pass" ],
-		"transitions": { "playCard": 2, "pass": 2 }
-	},
-*/
-
-	// Final state.
-	// Please do not modify (and do not overload action/args methods}.
-	"99": {
-		"name": "gameEnd",
-		"description": "End of game",
-		"type": "manager",
-		"action": "stGameEnd",
-		"args": "argGameEnd",
-		"argsType": "object" // Automatically typed by framework.
-	}
+  // Final state.
+  // Please do not modify (and do not overload action/args methods}.
+  "99": {
+    "name": "gameEnd",
+    "description": "End of game",
+    "type": "manager",
+    "action": "stGameEnd",
+    "args": "argGameEnd",
+    "argsType": "object" // Automatically typed by framework.
+  }
 }

--- a/source/shared/gamestates.jsonc
+++ b/source/shared/gamestates.jsonc
@@ -33,18 +33,30 @@
     "type": "activeplayer",
     "possibleactions": {
       "connectAstronauts": [],
-      "setAdrift": []
+      "actSetAdrift": [
+        {
+          "name": "cardDrawn",
+          "type": "AT_alphanum"
+        },
+        {
+          "name": "cardSetAdrift",
+          "type": "AT_alphanum"
+        }
+      ]
     },
-    "transitions": { "connectAstronauts": 20, "setAdrift": 20 }
+    "transitions": {
+      "finishConnectingAstronauts": 30,
+      "finishSettingAdrift": 30
+    }
   },
 
-  "20": {
+  "30": {
     "name": "nextPlayer",
     "description": "",
     "type": "game",
     "action": "stNextPlayer",
     "updateGameProgression": true,
-    "transitions": { "endGame": 99, "nextPlayer": 10 }
+    "transitions": { "goToGameEnd": 99, "goToNextPlayerTurn": 10 }
   },
 
   // Final state.

--- a/states.inc.php
+++ b/states.inc.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
  */
 if (false) {
 	/** @var tethergame $game */
+	$game->stDrawAtEndOfTurn();
 	$game->stNextPlayer();
 }
 
@@ -39,7 +40,16 @@ $machinestates = array(
 		'possibleactions' => ['connectAstronauts', 'actSetAdrift'],
 		'transitions' => array(
 			'finishConnectingAstronauts' => 30,
-			'finishSettingAdrift' => 30,
+			'drawAtEndOfTurn' => 25,
+		),
+	),
+	25 => array(
+		'name' => 'drawAtEndOfTurn',
+		'description' => clienttranslate('${actplayer} draws a card if they have fewer than 6 cards in hand'),
+		'type' => 'game',
+		'action' => 'stDrawAtEndOfTurn',
+		'transitions' => array(
+			'nextPlayer' => 30,
 		),
 	),
 	30 => array(

--- a/states.inc.php
+++ b/states.inc.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 if (false) {
 	/** @var tethergame $game */
-	
+	$game->stNextPlayer();
 }
 
 $machinestates = array(
@@ -28,18 +28,29 @@ $machinestates = array(
 		'type' => 'manager',
 		'action' => 'stGameSetup',
 		'transitions' => array(
-			'' => 2,
+			'' => 10,
 		),
 	),
-	2 => array(
-		'name' => 'dummmy',
-		'description' => clienttranslate('${actplayer} must play a card or pass'),
-		'descriptionmyturn' => clienttranslate('${you} must play a card or pass'),
+	10 => array(
+		'name' => 'playerTurn',
+		'description' => clienttranslate('${actplayer} must connect astronauts or set an astronaut adrift'),
+		'descriptionmyturn' => clienttranslate('${you} must connect astronauts or set an astronaut adrift'),
 		'type' => 'activeplayer',
-		'possibleactions' => ['playCard', 'pass'],
+		'possibleactions' => ['connectAstronauts', 'setAdrift'],
 		'transitions' => array(
-			'playCard' => 2,
-			'pass' => 2,
+			'connectAstronauts' => 20,
+			'setAdrift' => 20,
+		),
+	),
+	20 => array(
+		'name' => 'nextPlayer',
+		'description' => '',
+		'type' => 'game',
+		'action' => 'stNextPlayer',
+		'updateGameProgression' => true,
+		'transitions' => array(
+			'endGame' => 99,
+			'nextPlayer' => 10,
 		),
 	),
 	99 => array(

--- a/states.inc.php
+++ b/states.inc.php
@@ -36,21 +36,21 @@ $machinestates = array(
 		'description' => clienttranslate('${actplayer} must connect astronauts or set an astronaut adrift'),
 		'descriptionmyturn' => clienttranslate('${you} must connect astronauts or set an astronaut adrift'),
 		'type' => 'activeplayer',
-		'possibleactions' => ['connectAstronauts', 'setAdrift'],
+		'possibleactions' => ['connectAstronauts', 'actSetAdrift'],
 		'transitions' => array(
-			'connectAstronauts' => 20,
-			'setAdrift' => 20,
+			'finishConnectingAstronauts' => 30,
+			'finishSettingAdrift' => 30,
 		),
 	),
-	20 => array(
+	30 => array(
 		'name' => 'nextPlayer',
 		'description' => '',
 		'type' => 'game',
 		'action' => 'stNextPlayer',
 		'updateGameProgression' => true,
 		'transitions' => array(
-			'endGame' => 99,
-			'nextPlayer' => 10,
+			'goToGameEnd' => 99,
+			'goToNextPlayerTurn' => 10,
 		),
 	),
 	99 => array(

--- a/tethergame.action.php
+++ b/tethergame.action.php
@@ -31,15 +31,20 @@ class action_tethergame extends APP_GameAction
 	{
 		self::setAjaxMode();
 
-		$this->game->connectAstronauts(  );
+		$this->game->connectAstronauts();
 		self::ajaxResponse();
 	}
 
-	public function setAdrift()
+	public function actSetAdrift()
 	{
 		self::setAjaxMode();
 
-		$this->game->setAdrift(  );
+		/** @var string $cardDrawn */
+		$cardDrawn = self::getArg('cardDrawn', AT_alphanum, true);
+		/** @var string $cardSetAdrift */
+		$cardSetAdrift = self::getArg('cardSetAdrift', AT_alphanum, true);
+
+		$this->game->actSetAdrift($cardDrawn, $cardSetAdrift);
 		self::ajaxResponse();
 	}
 }

--- a/tethergame.action.php
+++ b/tethergame.action.php
@@ -27,22 +27,19 @@ class action_tethergame extends APP_GameAction
 		}
 	}
 
-	public function playCard()
+	public function connectAstronauts()
 	{
 		self::setAjaxMode();
 
-		/** @var int $card_id */
-		$card_id = self::getArg('card_id', AT_int, true);
-
-		$this->game->playCard( $card_id );
+		$this->game->connectAstronauts(  );
 		self::ajaxResponse();
 	}
 
-	public function pass()
+	public function setAdrift()
 	{
 		self::setAjaxMode();
 
-		$this->game->pass(  );
+		$this->game->setAdrift(  );
 		self::ajaxResponse();
 	}
 }

--- a/tethergame.action.php
+++ b/tethergame.action.php
@@ -31,7 +31,7 @@ class action_tethergame extends APP_GameAction
 	{
 		self::setAjaxMode();
 
-		$this->game->connectAstronauts();
+		$this->game->connectAstronauts(  );
 		self::ajaxResponse();
 	}
 
@@ -44,7 +44,7 @@ class action_tethergame extends APP_GameAction
 		/** @var string $cardSetAdrift */
 		$cardSetAdrift = self::getArg('cardSetAdrift', AT_alphanum, true);
 
-		$this->game->actSetAdrift($cardDrawn, $cardSetAdrift);
+		$this->game->actSetAdrift( $cardDrawn, $cardSetAdrift );
 		self::ajaxResponse();
 	}
 }

--- a/tethergame.css
+++ b/tethergame.css
@@ -57,6 +57,16 @@
   border: 1px dashed darkseagreen;
 }
 
+.deck {
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 5px;
+  margin: 5px;
+  width: 75px;
+  height: 105px;
+  background-color: steelblue;
+}
+
 .card {
   border: 1px solid black;
   border-radius: 5px;

--- a/tethergame.css
+++ b/tethergame.css
@@ -69,3 +69,10 @@
 .card--adrift {
   transform: rotate(90deg);
 }
+.card--selectable {
+  outline: 0.1rem dashed black;
+  cursor: pointer;
+}
+.card--selected {
+  outline: 0.25rem solid yellowgreen;
+}

--- a/tethergame.js
+++ b/tethergame.js
@@ -13,6 +13,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/counter"], function (require, exports, Gamegui) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -40,6 +76,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             var deck = document.createElement('div');
             deck.id = 'deck';
             deck.classList.add('deck');
+            deck.classList.add('js-deck');
             adriftZone.appendChild(deck);
             var hand = document.createElement('div');
             hand.id = 'hand';
@@ -111,8 +148,8 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
                     }, undefined, false, 'red');
                     break;
                 case 'client_setAdriftChooseDraw':
-                    this.addActionButton('draw-from-deck-button', _('Draw from deck'), function (e) {
-                        _this.drawFromDeck(e);
+                    this.addActionButton('draw-from-deck-button', _('Draw from deck'), function () {
+                        _this.performAdriftAction('deck');
                     });
                     break;
             }
@@ -142,8 +179,11 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             this.cardSetAdrift = null;
             this.restoreServerGameState();
         };
-        TetherGame.prototype.drawFromDeck = function (e) {
-            console.log('drawFromDeck must be implemented');
+        TetherGame.prototype.clearEventListeners = function () {
+            for (var _i = 0, _a = this.eventHandlers; _i < _a.length; _i++) {
+                var handler = _a[_i];
+                handler.element.removeEventListener(handler.event, handler.handler);
+            }
         };
         TetherGame.prototype.onSetAdriftHandClick = function (e) {
             var _this = this;
@@ -153,46 +193,82 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             e.target.classList.add('card--selected');
             this.cardSetAdrift = e.target.dataset['cardId'];
             this.clearSelectableCards();
-            for (var _i = 0, _a = this.eventHandlers; _i < _a.length; _i++) {
-                var handler = _a[_i];
-                handler.element.removeEventListener(handler.event, handler.handler);
-            }
             this.setClientState('client_setAdriftChooseDraw', {
                 descriptionmyturn: _('${you} must choose to take an astronaut from the adrift zone or draw from the deck.'),
             });
+            var deck = document.querySelector('.js-deck');
+            var drawFromDeckHandler = function () { return _this.performAdriftAction('deck'); };
+            if (deck instanceof HTMLElement) {
+                deck.classList.add('card--selectable');
+                deck.addEventListener('click', drawFromDeckHandler);
+                this.eventHandlers.push({
+                    element: deck,
+                    event: 'click',
+                    handler: drawFromDeckHandler,
+                });
+            }
             var adriftCards = document.querySelectorAll('.js-adrift');
-            var adriftHandler = function (e) { return _this.onAdriftCardDrawClick(e); };
+            var drawFromAdriftHandler = function (e) { return _this.onAdriftCardDrawClick(e); };
             adriftCards.forEach(function (card) {
                 if (card instanceof HTMLElement) {
                     card.classList.add('card--selectable');
-                    card.addEventListener('click', adriftHandler);
+                    card.addEventListener('click', drawFromAdriftHandler);
                     _this.eventHandlers.push({
                         element: card,
                         event: 'click',
-                        handler: adriftHandler,
+                        handler: drawFromAdriftHandler,
                     });
                 }
             });
         };
         TetherGame.prototype.onAdriftCardDrawClick = function (e) {
-            if (!(e.target instanceof HTMLElement)) {
-                throw new Error("onAdriftCardClick called when it shouldn't have been");
-            }
-            e.preventDefault();
-            e.stopPropagation();
-            if (!e.target.dataset['cardId'] || !this.cardSetAdrift) {
-                throw new Error('id of card to draw or cardSetAdrift not set properly');
-            }
-            this.clearSelectableCards();
-            this.clearSelectedCards();
-            var cardDrawn = e.target.dataset['cardId'];
-            var cardSetAdrift = this.cardSetAdrift;
-            console.table({ cardDrawn: cardDrawn, cardSetAdrift: cardSetAdrift });
-            this.bgaPerformAction('actSetAdrift', {
-                cardDrawn: e.target.dataset['cardId'],
-                cardSetAdrift: this.cardSetAdrift,
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
+                    if (!(e.target instanceof HTMLElement)) {
+                        throw new Error("onAdriftCardClick called when it shouldn't have been");
+                    }
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!e.target.dataset['cardId'] || !this.cardSetAdrift) {
+                        throw new Error('id of card to draw or cardSetAdrift not set properly');
+                    }
+                    this.performAdriftAction(e.target.dataset['cardId']);
+                    return [2];
+                });
             });
-            this.cardSetAdrift = null;
+        };
+        TetherGame.prototype.performAdriftAction = function (cardDrawn) {
+            return __awaiter(this, void 0, void 0, function () {
+                var e_1;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            if (!this.cardSetAdrift) {
+                                throw new Error('performAdriftAction is missing required information');
+                            }
+                            _a.label = 1;
+                        case 1:
+                            _a.trys.push([1, 3, , 4]);
+                            this.clearSelectableCards();
+                            this.clearSelectedCards();
+                            this.clearEventListeners();
+                            return [4, this.bgaPerformAction('actSetAdrift', {
+                                    cardDrawn: cardDrawn,
+                                    cardSetAdrift: this.cardSetAdrift,
+                                })];
+                        case 2:
+                            _a.sent();
+                            this.cardSetAdrift = null;
+                            return [3, 4];
+                        case 3:
+                            e_1 = _a.sent();
+                            this.restoreServerGameState();
+                            console.log('error while trying to perform actSetAdrift', e_1);
+                            return [3, 4];
+                        case 4: return [2];
+                    }
+                });
+            });
         };
         TetherGame.prototype.onSetAdriftClick = function (e) {
             var _this = this;

--- a/tethergame.js
+++ b/tethergame.js
@@ -20,6 +20,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
         __extends(TetherGame, _super);
         function TetherGame() {
             var _this = _super.call(this) || this;
+            _this.eventHandlers = [];
             _this.setupNotifications = function () {
                 console.log('notifications subscriptions setup');
             };
@@ -47,8 +48,10 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             }
             for (var cardId in gamedatas.hand) {
                 var cardElement = document.createElement('div');
+                var cardNumber = gamedatas.hand[cardId].type_arg;
+                cardElement.dataset['cardNumber'] = cardNumber;
                 cardElement.classList.add('card');
-                cardElement.innerText = gamedatas.hand[cardId].type_arg;
+                cardElement.innerText = cardNumber;
                 hand.appendChild(cardElement);
             }
             this.setupNotifications();
@@ -74,6 +77,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             }
         };
         TetherGame.prototype.onUpdateActionButtons = function () {
+            var _this = this;
             var _a = [];
             for (var _i = 0; _i < arguments.length; _i++) {
                 _a[_i] = arguments[_i];
@@ -83,9 +87,75 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             if (!this.isCurrentPlayerActive())
                 return;
             switch (stateName) {
-                default:
+                case 'playerTurn':
+                    this.addActionButton('connect-astronauts-button', _('Connect Astronauts'), function () {
+                        console.log('not implemented yet');
+                    }, undefined, false, 'gray');
+                    this.addActionButton('set-adrift-button', _('Set Astronauts Adrift'), function (e) {
+                        _this.onSetAdriftClick(e);
+                    });
                     break;
+                case 'client_setAdriftChooseFromHand':
+                    this.addActionButton('cancel-button', _('Restart turn'), function () {
+                        _this.cancelSetAdriftAction();
+                    }, undefined, false, 'red');
             }
+        };
+        TetherGame.prototype.getCardElementsFromHand = function () {
+            var hand = document.getElementById('hand');
+            if (!hand) {
+                throw new Error('hand not found');
+            }
+            return hand.childNodes;
+        };
+        TetherGame.prototype.cancelSetAdriftAction = function () {
+            var selectedCards = document.querySelectorAll('.card--selected');
+            selectedCards.forEach(function (card) {
+                card.classList.remove('card--selected');
+            });
+            var selectableCards = document.querySelectorAll('.card--selectable');
+            selectableCards.forEach(function (card) {
+                card.classList.remove('card--selectable');
+            });
+            this.restoreServerGameState();
+        };
+        TetherGame.prototype.onSetAdriftHandClick = function (e) {
+            if (!(e.target instanceof HTMLElement)) {
+                throw new Error("onSetAdriftHandClick called when it shouldn't have been");
+            }
+            e.target.classList.add('card--selected');
+            this.getCardElementsFromHand().forEach(function (card) {
+                if (card instanceof HTMLElement) {
+                    card.classList.remove('card--selectable');
+                }
+            });
+            for (var _i = 0, _a = this.eventHandlers; _i < _a.length; _i++) {
+                var handler = _a[_i];
+                handler.element.removeEventListener(handler.event, handler.handler);
+            }
+        };
+        TetherGame.prototype.onSetAdriftClick = function (e) {
+            var _this = this;
+            if (!(e.target instanceof HTMLElement)) {
+                throw new Error("onSetAdriftClick called when it shouldn't have been");
+            }
+            e.preventDefault();
+            e.stopPropagation();
+            this.setClientState('client_setAdriftChooseFromHand', {
+                descriptionmyturn: _('${you} must select an astronaut from your hand to set adrift.'),
+            });
+            var handler = function (e) { return _this.onSetAdriftHandClick(e); };
+            this.getCardElementsFromHand().forEach(function (card) {
+                if (card instanceof HTMLElement) {
+                    card.classList.add('card--selectable');
+                    card.addEventListener('click', handler);
+                    _this.eventHandlers.push({
+                        element: card,
+                        event: 'click',
+                        handler: handler,
+                    });
+                }
+            });
         };
         return TetherGame;
     }(Gamegui));

--- a/tethergame.js
+++ b/tethergame.js
@@ -62,14 +62,14 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             var stateName = _a[0], state = _a[1];
             console.log('Entering state: ' + stateName);
             switch (stateName) {
-                case 'dummmy':
+                default:
                     break;
             }
         };
         TetherGame.prototype.onLeavingState = function (stateName) {
             console.log('Leaving state: ' + stateName);
             switch (stateName) {
-                case 'dummmy':
+                default:
                     break;
             }
         };
@@ -83,7 +83,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             if (!this.isCurrentPlayerActive())
                 return;
             switch (stateName) {
-                case 'dummmy':
+                default:
                     break;
             }
         };

--- a/tethergame.js
+++ b/tethergame.js
@@ -44,17 +44,20 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             var hand = document.createElement('div');
             hand.id = 'hand';
             gamePlayArea.appendChild(hand);
-            for (var cardNum in gamedatas.adrift) {
+            for (var cardId in gamedatas.adrift) {
                 var cardElement = document.createElement('div');
                 cardElement.classList.add('card');
                 cardElement.classList.add('card--adrift');
                 cardElement.classList.add('js-adrift');
+                cardElement.dataset['cardId'] = cardId;
+                var cardNum = gamedatas.adrift[cardId].cardNum;
                 cardElement.dataset['cardNumber'] = cardNum;
                 cardElement.innerText = cardNum;
                 adriftZone.appendChild(cardElement);
             }
             for (var cardId in gamedatas.hand) {
                 var cardElement = document.createElement('div');
+                cardElement.dataset['cardId'] = cardId;
                 var cardNumber = gamedatas.hand[cardId].type_arg;
                 cardElement.dataset['cardNumber'] = cardNumber;
                 cardElement.innerText = cardNumber;
@@ -106,10 +109,12 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
                     this.addActionButton('cancel-button', _('Restart turn'), function () {
                         _this.cancelSetAdriftAction();
                     }, undefined, false, 'red');
+                    break;
                 case 'client_setAdriftChooseDraw':
                     this.addActionButton('draw-from-deck-button', _('Draw from deck'), function (e) {
                         _this.drawFromDeck(e);
                     });
+                    break;
             }
         };
         TetherGame.prototype.getCardElementsFromHand = function () {
@@ -146,7 +151,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
                 throw new Error("onSetAdriftHandClick called when it shouldn't have been");
             }
             e.target.classList.add('card--selected');
-            this.cardSetAdrift = e.target.dataset['cardNumber'];
+            this.cardSetAdrift = e.target.dataset['cardId'];
             this.clearSelectableCards();
             for (var _i = 0, _a = this.eventHandlers; _i < _a.length; _i++) {
                 var handler = _a[_i];
@@ -175,13 +180,16 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "ebg/cou
             }
             e.preventDefault();
             e.stopPropagation();
-            if (!e.target.dataset['cardNumber'] || !this.cardSetAdrift) {
-                throw new Error('cardNumber or cardSetAdrift not set properly');
+            if (!e.target.dataset['cardId'] || !this.cardSetAdrift) {
+                throw new Error('id of card to draw or cardSetAdrift not set properly');
             }
             this.clearSelectableCards();
             this.clearSelectedCards();
-            this.bgaPerformAction('setAdrift', {
-                cardDrawn: e.target.dataset['cardNumber'],
+            var cardDrawn = e.target.dataset['cardId'];
+            var cardSetAdrift = this.cardSetAdrift;
+            console.table({ cardDrawn: cardDrawn, cardSetAdrift: cardSetAdrift });
+            this.bgaPerformAction('actSetAdrift', {
+                cardDrawn: e.target.dataset['cardId'],
                 cardSetAdrift: this.cardSetAdrift,
             });
             this.cardSetAdrift = null;


### PR DESCRIPTION
## Overview

- Resolves #7 
- Adds "Set astronaut adrift" action
- Adds drawAtEndOfTurn state and nextPlayer state
- Adds deck to adrift zone and styles for selectable/selected cards

### Next

- Add BGA notifications to update the UI after the action instead of requiring a refresh