### PR TITLE
Add hand and adrift to UI state and fix vertical ordering bug

### DIFF
--- a/source/client/generateBoard.spec.ts
+++ b/source/client/generateBoard.spec.ts
@@ -14,15 +14,36 @@ gen(
         '01': { id: '1', number: '01', uprightFor: 'vertical' },
       },
       horizontal: {
-        '02': { id: '2', number: '02', uprightFor: 'horizontal' },
-        '03': { id: '3', number: '03', uprightFor: 'horizontal' },
-        '01': { id: '1', number: '01', uprightFor: 'horizontal' },
+        '02': { id: '2', number: '02', uprightFor: 'vertical' },
+        '03': { id: '3', number: '03', uprightFor: 'vertical' },
+        '01': { id: '1', number: '01', uprightFor: 'vertical' },
       },
     });
     assert.equal(result, [
       [{ id: '1', number: '01', uprightFor: 'vertical' }],
       [{ id: '2', number: '02', uprightFor: 'vertical' }],
       [{ id: '3', number: '03', uprightFor: 'vertical' }],
+    ]);
+  }
+);
+
+gen(
+  'should sort the cards correctly based on what card is showing face up',
+  () => {
+    const result = generateGroupUI({
+      vertical: {
+        '02': { id: '2', number: '02', uprightFor: 'horizontal' },
+        '01': { id: '1', number: '19', uprightFor: 'vertical' },
+      },
+      horizontal: {
+        '02': { id: '2', number: '02', uprightFor: 'horizontal' },
+        '01': { id: '1', number: '19', uprightFor: 'vertical' },
+      },
+    });
+
+    assert.equal(result, [
+      [{ id: '1', number: '19', uprightFor: 'vertical' }],
+      [{ id: '2', number: '02', uprightFor: 'horizontal' }],
     ]);
   }
 );

--- a/source/client/generateBoard.ts
+++ b/source/client/generateBoard.ts
@@ -30,12 +30,24 @@ export interface BoardUI {
   [groupNum: string]: GroupUI;
 }
 
+function reverseString(str: string) {
+  return str.split('').reverse().join('');
+}
+
 export function generateGroupUI(group: Group): GroupUI {
   const verticalCards = group.vertical && Object.values(group.vertical);
   const horizontalCards = group.horizontal && Object.values(group.horizontal);
   if (verticalCards) {
     return verticalCards
-      .sort((a, b) => parseInt(a.number) - parseInt(b.number))
+      .sort((a, b) => {
+        const aNum = parseInt(
+          a.uprightFor === 'vertical' ? a.number : reverseString(a.number)
+        );
+        const bNum = parseInt(
+          b.uprightFor === 'vertical' ? b.number : reverseString(b.number)
+        );
+        return aNum - bNum;
+      })
       .map((card) => {
         return [{ ...card }];
       });

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -61,8 +61,10 @@ class TetherGame extends Gamegui {
 
   gameState: {
     board: BGA.Gamedatas['board'];
+    hand: BGA.Gamedatas['hand'];
   } = {
     board: {},
+    hand: {},
   };
 
   playerDirection: 'horizontal' | 'vertical' | null = null;
@@ -108,6 +110,20 @@ class TetherGame extends Gamegui {
 
   // TODO: this redraw function needs to handle animations in the future?
   updateBoardUI() {
+    const hand = document.getElementById('hand');
+    if (!hand) {
+      throw new Error('hand not found');
+    }
+    hand.innerHTML = '';
+    for (const cardId in this.gameState.hand) {
+      const cardEl = this.createCardElement({
+        id: cardId,
+        number: this.gameState.hand[cardId]!.type_arg,
+        flipped: false,
+      });
+      hand.appendChild(cardEl);
+    }
+
     const groupsArea = document.getElementById('groups');
     if (!groupsArea) {
       throw new Error('groups not found');
@@ -176,15 +192,6 @@ class TetherGame extends Gamegui {
       adriftZone.appendChild(cardEl);
     }
 
-    for (const cardId in gamedatas.hand) {
-      const cardEl = this.createCardElement({
-        id: cardId,
-        number: gamedatas.hand[cardId]!.type_arg,
-        flipped: false,
-      });
-      hand.appendChild(cardEl);
-    }
-
     if (!this.player_id) {
       throw new Error('player_id not found');
     }
@@ -197,6 +204,7 @@ class TetherGame extends Gamegui {
         : 'horizontal';
 
     this.gameState.board = gamedatas.board;
+    this.gameState.hand = gamedatas.hand;
     this.updateBoardUI();
 
     // Setup game notifications to handle (see "setupNotifications" method below)
@@ -695,6 +703,7 @@ class TetherGame extends Gamegui {
       flipped,
     };
 
+    delete this.gameState.hand[this.cardForConnecting.id];
     if (first) {
       const existingGroupsLen = Object.keys(this.gameState.board).length;
       this.currentGroup = existingGroupsLen + 1;
@@ -724,20 +733,6 @@ class TetherGame extends Gamegui {
       };
       this.updateBoardUI();
     }
-
-    // TODO: this should be part of the board state? cards in hand
-    // move the card from hand to a new group
-    const hand = document.getElementById('hand');
-    if (!hand) {
-      throw new Error('hand not found');
-    }
-    const cardToRemove = hand.querySelector(
-      `[data-card-id="${this.cardForConnecting.id}"]`
-    );
-    if (!cardToRemove) {
-      throw new Error('card to remove not found');
-    }
-    hand.removeChild(cardToRemove);
 
     this.highlightPlayableAstronauts();
   }

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -59,7 +59,11 @@ class TetherGame extends Gamegui {
 
   board: BoardUI = {};
 
-  boardState: BGA.Gamedatas['board'] = {};
+  gameState: {
+    board: BGA.Gamedatas['board'];
+  } = {
+    board: {},
+  };
 
   playerDirection: 'horizontal' | 'vertical' | null = null;
 
@@ -111,8 +115,8 @@ class TetherGame extends Gamegui {
     groupsArea.innerHTML = '';
 
     let groups: Record<string, GroupUI> = {};
-    for (const group in this.boardState) {
-      const generatedGroup = generateGroupUI(this.boardState[group]!);
+    for (const group in this.gameState.board) {
+      const generatedGroup = generateGroupUI(this.gameState.board[group]!);
       groups[group] = generatedGroup;
 
       const groupEl = document.createElement('div');
@@ -192,7 +196,7 @@ class TetherGame extends Gamegui {
         ? 'vertical'
         : 'horizontal';
 
-    this.boardState = gamedatas.board;
+    this.gameState.board = gamedatas.board;
     this.updateBoardUI();
 
     // Setup game notifications to handle (see "setupNotifications" method below)
@@ -692,17 +696,14 @@ class TetherGame extends Gamegui {
     };
 
     if (first) {
-      if (!this.boardState) {
-        this.boardState = {};
-      }
-      const existingGroupsLen = Object.keys(this.boardState).length;
+      const existingGroupsLen = Object.keys(this.gameState.board).length;
       this.currentGroup = existingGroupsLen + 1;
-      this.boardState[this.currentGroup] = this.createGroupFromCard(
+      this.gameState.board[this.currentGroup] = this.createGroupFromCard(
         this.cardForConnecting
       );
       this.updateBoardUI();
     } else {
-      const group = this.boardState[this.currentGroup];
+      const group = this.gameState.board[this.currentGroup];
       if (!group) {
         throw new Error('current group not found');
       }
@@ -751,8 +752,8 @@ class TetherGame extends Gamegui {
     type Groups = Record<string, Card[]>;
     const groups: Groups = {};
 
-    for (const groupNum in this.boardState) {
-      const group = this.boardState[groupNum];
+    for (const groupNum in this.gameState.board) {
+      const group = this.gameState.board[groupNum];
       if (!group) break;
       for (const cardNum in group.vertical) {
         if (!group['vertical']?.[cardNum]) {

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -60,9 +60,11 @@ class TetherGame extends Gamegui {
   board: BoardUI = {};
 
   gameState: {
+    adrift: BGA.Gamedatas['adrift'];
     board: BGA.Gamedatas['board'];
     hand: BGA.Gamedatas['hand'];
   } = {
+    adrift: {},
     board: {},
     hand: {},
   };
@@ -110,6 +112,26 @@ class TetherGame extends Gamegui {
 
   // TODO: this redraw function needs to handle animations in the future?
   updateBoardUI() {
+    const adriftZone = document.getElementById('adrift-zone');
+    if (!adriftZone) {
+      throw new Error('adrift-zone not found');
+    }
+    adriftZone.innerHTML = '';
+
+    const deck = document.createElement('div');
+    deck.id = 'deck';
+    deck.classList.add('deck');
+    deck.classList.add('js-deck');
+    adriftZone.appendChild(deck);
+
+    for (const cardId in this.gameState.adrift) {
+      const cardEl = this.createAdriftCardElement(
+        cardId,
+        this.gameState.adrift[cardId]!.cardNum
+      );
+      adriftZone.appendChild(cardEl);
+    }
+
     const hand = document.getElementById('hand');
     if (!hand) {
       throw new Error('hand not found');
@@ -169,12 +191,6 @@ class TetherGame extends Gamegui {
     adriftZone.id = 'adrift-zone';
     gamePlayArea.appendChild(adriftZone);
 
-    const deck = document.createElement('div');
-    deck.id = 'deck';
-    deck.classList.add('deck');
-    deck.classList.add('js-deck');
-    adriftZone.appendChild(deck);
-
     const groupsArea = document.createElement('div');
     groupsArea.id = 'groups';
     groupsArea.classList.add('groups');
@@ -183,14 +199,6 @@ class TetherGame extends Gamegui {
     const hand = document.createElement('div');
     hand.id = 'hand';
     gamePlayArea.appendChild(hand);
-
-    for (const cardId in gamedatas.adrift) {
-      const cardEl = this.createAdriftCardElement(
-        cardId,
-        gamedatas.adrift[cardId]!.cardNum
-      );
-      adriftZone.appendChild(cardEl);
-    }
 
     if (!this.player_id) {
       throw new Error('player_id not found');
@@ -203,6 +211,7 @@ class TetherGame extends Gamegui {
         ? 'vertical'
         : 'horizontal';
 
+    this.gameState.adrift = gamedatas.adrift;
     this.gameState.board = gamedatas.board;
     this.gameState.hand = gamedatas.hand;
     this.updateBoardUI();

--- a/tethergame.js
+++ b/tethergame.js
@@ -97,7 +97,9 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             _this.cardForConnecting = null;
             _this.currentGroup = 0;
             _this.board = {};
-            _this.boardState = {};
+            _this.gameState = {
+                board: {},
+            };
             _this.playerDirection = null;
             _this.playableCardNumbers = [];
             _this.setupNotifications = function () {
@@ -144,8 +146,8 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             }
             groupsArea.innerHTML = '';
             var groups = {};
-            for (var group in this.boardState) {
-                var generatedGroup = (0, generateBoard_1.generateGroupUI)(this.boardState[group]);
+            for (var group in this.gameState.board) {
+                var generatedGroup = (0, generateBoard_1.generateGroupUI)(this.gameState.board[group]);
                 groups[group] = generatedGroup;
                 var groupEl = document.createElement('div');
                 groupEl.classList.add('group');
@@ -209,7 +211,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                 ((_a = gamedatas.players[this.player_id]) === null || _a === void 0 ? void 0 : _a.turnOrder) === '1'
                     ? 'vertical'
                     : 'horizontal';
-            this.boardState = gamedatas.board;
+            this.gameState.board = gamedatas.board;
             this.updateBoardUI();
             this.setupNotifications();
             console.log('Ending game setup');
@@ -568,16 +570,13 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                 flipped: flipped,
             };
             if (first) {
-                if (!this.boardState) {
-                    this.boardState = {};
-                }
-                var existingGroupsLen = Object.keys(this.boardState).length;
+                var existingGroupsLen = Object.keys(this.gameState.board).length;
                 this.currentGroup = existingGroupsLen + 1;
-                this.boardState[this.currentGroup] = this.createGroupFromCard(this.cardForConnecting);
+                this.gameState.board[this.currentGroup] = this.createGroupFromCard(this.cardForConnecting);
                 this.updateBoardUI();
             }
             else {
-                var group = this.boardState[this.currentGroup];
+                var group = this.gameState.board[this.currentGroup];
                 if (!group) {
                     throw new Error('current group not found');
                 }
@@ -610,8 +609,8 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
         TetherGame.prototype.getGroupsOfCardIDsFromBoardState = function () {
             var _a, _b, _c;
             var groups = {};
-            for (var groupNum in this.boardState) {
-                var group = this.boardState[groupNum];
+            for (var groupNum in this.gameState.board) {
+                var group = this.gameState.board[groupNum];
                 if (!group)
                     break;
                 for (var cardNum in group.vertical) {

--- a/tethergame.js
+++ b/tethergame.js
@@ -64,12 +64,19 @@ define("generateBoard", ["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.generateGroupUI = generateGroupUI;
+    function reverseString(str) {
+        return str.split('').reverse().join('');
+    }
     function generateGroupUI(group) {
         var verticalCards = group.vertical && Object.values(group.vertical);
         var horizontalCards = group.horizontal && Object.values(group.horizontal);
         if (verticalCards) {
             return verticalCards
-                .sort(function (a, b) { return parseInt(a.number) - parseInt(b.number); })
+                .sort(function (a, b) {
+                var aNum = parseInt(a.uprightFor === 'vertical' ? a.number : reverseString(a.number));
+                var bNum = parseInt(b.uprightFor === 'vertical' ? b.number : reverseString(b.number));
+                return aNum - bNum;
+            })
                 .map(function (card) {
                 return [__assign({}, card)];
             });

--- a/tethergame.js
+++ b/tethergame.js
@@ -98,6 +98,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             _this.currentGroup = 0;
             _this.board = {};
             _this.gameState = {
+                adrift: {},
                 board: {},
                 hand: {},
             };
@@ -141,6 +142,20 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             return cardElement;
         };
         TetherGame.prototype.updateBoardUI = function () {
+            var adriftZone = document.getElementById('adrift-zone');
+            if (!adriftZone) {
+                throw new Error('adrift-zone not found');
+            }
+            adriftZone.innerHTML = '';
+            var deck = document.createElement('div');
+            deck.id = 'deck';
+            deck.classList.add('deck');
+            deck.classList.add('js-deck');
+            adriftZone.appendChild(deck);
+            for (var cardId in this.gameState.adrift) {
+                var cardEl = this.createAdriftCardElement(cardId, this.gameState.adrift[cardId].cardNum);
+                adriftZone.appendChild(cardEl);
+            }
             var hand = document.getElementById('hand');
             if (!hand) {
                 throw new Error('hand not found');
@@ -194,11 +209,6 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             var adriftZone = document.createElement('div');
             adriftZone.id = 'adrift-zone';
             gamePlayArea.appendChild(adriftZone);
-            var deck = document.createElement('div');
-            deck.id = 'deck';
-            deck.classList.add('deck');
-            deck.classList.add('js-deck');
-            adriftZone.appendChild(deck);
             var groupsArea = document.createElement('div');
             groupsArea.id = 'groups';
             groupsArea.classList.add('groups');
@@ -206,10 +216,6 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             var hand = document.createElement('div');
             hand.id = 'hand';
             gamePlayArea.appendChild(hand);
-            for (var cardId in gamedatas.adrift) {
-                var cardEl = this.createAdriftCardElement(cardId, gamedatas.adrift[cardId].cardNum);
-                adriftZone.appendChild(cardEl);
-            }
             if (!this.player_id) {
                 throw new Error('player_id not found');
             }
@@ -217,6 +223,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                 ((_a = gamedatas.players[this.player_id]) === null || _a === void 0 ? void 0 : _a.turnOrder) === '1'
                     ? 'vertical'
                     : 'horizontal';
+            this.gameState.adrift = gamedatas.adrift;
             this.gameState.board = gamedatas.board;
             this.gameState.hand = gamedatas.hand;
             this.updateBoardUI();

--- a/tethergame.js
+++ b/tethergame.js
@@ -99,6 +99,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             _this.board = {};
             _this.gameState = {
                 board: {},
+                hand: {},
             };
             _this.playerDirection = null;
             _this.playableCardNumbers = [];
@@ -140,6 +141,19 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
             return cardElement;
         };
         TetherGame.prototype.updateBoardUI = function () {
+            var hand = document.getElementById('hand');
+            if (!hand) {
+                throw new Error('hand not found');
+            }
+            hand.innerHTML = '';
+            for (var cardId in this.gameState.hand) {
+                var cardEl = this.createCardElement({
+                    id: cardId,
+                    number: this.gameState.hand[cardId].type_arg,
+                    flipped: false,
+                });
+                hand.appendChild(cardEl);
+            }
             var groupsArea = document.getElementById('groups');
             if (!groupsArea) {
                 throw new Error('groups not found');
@@ -196,14 +210,6 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                 var cardEl = this.createAdriftCardElement(cardId, gamedatas.adrift[cardId].cardNum);
                 adriftZone.appendChild(cardEl);
             }
-            for (var cardId in gamedatas.hand) {
-                var cardEl = this.createCardElement({
-                    id: cardId,
-                    number: gamedatas.hand[cardId].type_arg,
-                    flipped: false,
-                });
-                hand.appendChild(cardEl);
-            }
             if (!this.player_id) {
                 throw new Error('player_id not found');
             }
@@ -212,6 +218,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                     ? 'vertical'
                     : 'horizontal';
             this.gameState.board = gamedatas.board;
+            this.gameState.hand = gamedatas.hand;
             this.updateBoardUI();
             this.setupNotifications();
             console.log('Ending game setup');
@@ -569,6 +576,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                 number: this.cardForConnecting.number,
                 flipped: flipped,
             };
+            delete this.gameState.hand[this.cardForConnecting.id];
             if (first) {
                 var existingGroupsLen = Object.keys(this.gameState.board).length;
                 this.currentGroup = existingGroupsLen + 1;
@@ -595,15 +603,6 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "generat
                 };
                 this.updateBoardUI();
             }
-            var hand = document.getElementById('hand');
-            if (!hand) {
-                throw new Error('hand not found');
-            }
-            var cardToRemove = hand.querySelector("[data-card-id=\"".concat(this.cardForConnecting.id, "\"]"));
-            if (!cardToRemove) {
-                throw new Error('card to remove not found');
-            }
-            hand.removeChild(cardToRemove);
             this.highlightPlayableAstronauts();
         };
         TetherGame.prototype.getGroupsOfCardIDsFromBoardState = function () {


### PR DESCRIPTION
## Overview

- Adds hand and adrift cards into the UI memory state and updates it in the re-rendering function.
- Fixes a bug with ordering card incorrectly e.g. 20->19 instead of 19->20 because the "original" number of the 20 is 02.