### PR TITLE
Restore restart turn for Connect Astronauts action

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "npx bga-build",
     "watch": "npx bga-build --watch",
     "test": "uvu -r tsm",
-    "test:watch": "npm test; watchlist source/client -- npm test"
+    "test:watch": "npm test; watchlist source/client -- npm test",
+    "typecheck": "tsc -p ./source/client/tsconfig.json --noEmit"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview

- New data representation needs new way to restart turn and restore state
- Adds typecheck script
- Restores ability to restart turn after beginning a "Connect Astronauts" turn

## TODOs

- We never update the state "from the beginning of the turn" - we need to add handling to update this whenever we get a notification for the new turn.