### PR TITLE
Update and save state in FE at the beginning of each turn

### DIFF
--- a/modules/php/Game.php
+++ b/modules/php/Game.php
@@ -488,6 +488,27 @@ class Game extends \Table
                     }
                 }
             }
+            // TODO: personalize the notification
+            $current_player_id = (int) $this->getCurrentPlayerId();
+            $opponent_id = $this->getPlayerAfter($current_player_id);
+            $adrift = $this->getCollectionFromDB(
+                "SELECT card_id id, card_type_arg cardNum
+                FROM card 
+                WHERE card_location = 'adrift'"
+            );
+            $cardsByGroup = $this->getCollectionFromDB(
+                "SELECT card_id id, card_type uprightFor, card_type_arg cardNum, card_location_arg groupAndCoords
+                FROM card 
+                WHERE card_location = 'group'"
+            );
+            $board = $this->createGroupObjectForUI($cardsByGroup);
+            $this->notifyPlayer($opponent_id, 'updateBoardAndAdrift', clienttranslate('${player_name} played some cards TO BE MORE SPECIFIC.'), [
+                'player_id' => $current_player_id,
+                'player_name' => $this->getPlayerNameById($current_player_id),
+                'adrift' => $adrift,
+                'board' => $board,
+            ]);
+            $this->notifyPlayer($current_player_id, 'connectAstronautComplete', clienttranslate('You connected some astronauts.'), []);
         } catch (\Exception $e) {
             $this->error("Error while connecting astronauts");
             $this->dump('err', $e);

--- a/source/client/build/gamestates.d.ts
+++ b/source/client/build/gamestates.d.ts
@@ -25,6 +25,7 @@ interface DefinedGameStates extends ValidateGameStates<{
 		'name': 'playerTurn',
 		'description': '${actplayer} must connect astronauts or set an astronaut adrift',
 		'descriptionmyturn': '${you} must connect astronauts or set an astronaut adrift',
+		'action': 'stPlayerTurn',
 		'type': 'activeplayer',
 		'args': 'argPlayerTurn',
 		'possibleactions': ['actConnectAstronauts', 'actSetAdrift'],

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -860,8 +860,9 @@ class TetherGame extends Gamegui {
       (notif) => notif.args.player_id === this.player_id
     );
     this.notifqueue.setSynchronous('drawOtherPlayer', 500);
-    dojo.subscribe('updateBoardAndAdrift', this, 'notif_updateBoardAndAdrift');
-    this.notifqueue.setSynchronous('updateBoardAndAdrift', 500);
+
+    dojo.subscribe('updateGameState', this, 'notif_updateGameState');
+    this.notifqueue.setSynchronous('updateGameState', 500);
 
     // dojo.subscribe( 'cardPlayed_1', this, "ntf_any" );
     // dojo.subscribe( 'actionTaken', this, "ntf_actionTaken" );
@@ -977,9 +978,10 @@ class TetherGame extends Gamegui {
     hand.appendChild(cardEl);
   }
 
-  notif_updateBoardAndAdrift(notif: BGA.Notif<'updateBoardAndAdrift'>) {
+  notif_updateGameState(notif: BGA.Notif<'updateGameState'>) {
     this.gameStateTurnStart.adrift = notif.args.adrift;
     this.gameStateTurnStart.board = notif.args.board;
+    this.gameStateTurnStart.hand = notif.args.hand;
     this.gameStateCurrent = clone(this.gameStateTurnStart);
     this.updateBoardUI();
   }

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -860,6 +860,8 @@ class TetherGame extends Gamegui {
       (notif) => notif.args.player_id === this.player_id
     );
     this.notifqueue.setSynchronous('drawOtherPlayer', 500);
+    dojo.subscribe('updateBoardAndAdrift', this, 'notif_updateBoardAndAdrift');
+    this.notifqueue.setSynchronous('updateBoardAndAdrift', 500);
 
     // dojo.subscribe( 'cardPlayed_1', this, "ntf_any" );
     // dojo.subscribe( 'actionTaken', this, "ntf_actionTaken" );
@@ -973,6 +975,13 @@ class TetherGame extends Gamegui {
       throw new Error('hand not found');
     }
     hand.appendChild(cardEl);
+  }
+
+  notif_updateBoardAndAdrift(notif: BGA.Notif<'updateBoardAndAdrift'>) {
+    this.gameStateTurnStart.adrift = notif.args.adrift;
+    this.gameStateTurnStart.board = notif.args.board;
+    this.gameStateCurrent = clone(this.gameStateTurnStart);
+    this.updateBoardUI();
   }
 }
 

--- a/source/shared/gamestates.jsonc
+++ b/source/shared/gamestates.jsonc
@@ -30,6 +30,7 @@
     "name": "playerTurn",
     "description": "${actplayer} must connect astronauts or set an astronaut adrift",
     "descriptionmyturn": "${you} must connect astronauts or set an astronaut adrift",
+    "action": "stPlayerTurn",
     "type": "activeplayer",
     "args": "argPlayerTurn",
     "possibleactions": {

--- a/states.inc.php
+++ b/states.inc.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
  */
 if (false) {
 	/** @var tethergame $game */
+	$game->stPlayerTurn();
 	$game->stFinishConnectingAstronauts();
 	$game->stDrawAtEndOfTurn();
 	$game->stNextPlayer();
@@ -37,6 +38,7 @@ $machinestates = array(
 		'name' => 'playerTurn',
 		'description' => clienttranslate('${actplayer} must connect astronauts or set an astronaut adrift'),
 		'descriptionmyturn' => clienttranslate('${you} must connect astronauts or set an astronaut adrift'),
+		'action' => 'stPlayerTurn',
 		'type' => 'activeplayer',
 		'args' => 'argPlayerTurn',
 		'possibleactions' => ['actConnectAstronauts', 'actSetAdrift'],


### PR DESCRIPTION
## Overview

- Our "restart turn" function for Connect Astronauts is based on a saved state. Prior to this PR, we never updated the saved state, so pressing the button would send the UI state back to the state of the last refresh.
- This PR adds code to update and save the state at the beginning of each player's turn. Additionally, it updates the board UI so everything should be up to date.