### PR TITLE
Only highlight valid playable cards during Connect Astronauts action

### DIFF
--- a/source/client/getConnectingNumbers.spec.ts
+++ b/source/client/getConnectingNumbers.spec.ts
@@ -1,0 +1,23 @@
+import { getConnectingNumbers } from './getConnectingNumbers';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+test('getConnectingNumbers should behave as expected', () => {
+  assert.throws(
+    () => getConnectingNumbers('0'),
+    'the number string should be exactly 2 characters long'
+  );
+  assert.throws(
+    () => getConnectingNumbers('00'),
+    'the number must be between 01 and 98'
+  );
+  assert.throws(
+    () => getConnectingNumbers('99'),
+    'the number must be between 01 and 98'
+  );
+
+  assert.equal(getConnectingNumbers('32'), ['31', '33']);
+  assert.equal(getConnectingNumbers('02'), ['01', '03']);
+});
+
+test.run();

--- a/source/client/getConnectingNumbers.ts
+++ b/source/client/getConnectingNumbers.ts
@@ -1,0 +1,14 @@
+export function getConnectingNumbers(num: string) {
+  if (num.length !== 2) {
+    throw new Error('the number string should be exactly 2 characters long');
+  }
+  const parsedNum = parseInt(num);
+  if (parsedNum < 1 || parsedNum > 98) {
+    throw new Error('the number must be between 01 and 98');
+  }
+
+  const decremented = (parsedNum - 1).toString().padStart(2, '0');
+  const incremented = (parsedNum + 1).toString().padStart(2, '0');
+
+  return [decremented, incremented];
+}

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -376,7 +376,7 @@ class TetherGame extends Gamegui {
             });
           }
         );
-        const isNumPlayable = this.numberIsPlayable(number);
+        const isNumPlayable = this.isNumPlayable(number);
         if (!isNumPlayable) {
           document
             .getElementById('play-upright-button')
@@ -393,7 +393,7 @@ class TetherGame extends Gamegui {
             });
           }
         );
-        const isFlippedNumPlayable = this.numberIsPlayable(numReversed);
+        const isFlippedNumPlayable = this.isNumPlayable(numReversed);
         if (!isFlippedNumPlayable) {
           document
             .getElementById('play-flipped-button')
@@ -633,14 +633,14 @@ class TetherGame extends Gamegui {
     this.restoreUIToTurnStart();
   }
 
-  cardIsPlayable(card: HTMLElement) {
+  isCardPlayable(card: HTMLElement) {
     return (
-      this.numberIsPlayable(card.dataset['cardNumber']) ||
-      this.numberIsPlayable(card.dataset['cardNumReversed'])
+      this.isNumPlayable(card.dataset['cardNumber']) ||
+      this.isNumPlayable(card.dataset['cardNumReversed'])
     );
   }
 
-  numberIsPlayable(number: string | undefined) {
+  isNumPlayable(number: string | undefined) {
     return (
       typeof number === 'string' && this.playableCardNumbers.includes(number)
     );
@@ -654,7 +654,7 @@ class TetherGame extends Gamegui {
     const handler = (e: Event) => this.handleChooseCardFromHandConnect(e);
     this.getCardElementsFromHand().forEach((card) => {
       if (card instanceof HTMLElement) {
-        if (this.cardIsPlayable(card)) {
+        if (this.isCardPlayable(card)) {
           card.classList.add('card--selectable');
           card.addEventListener('click', handler);
           this.eventHandlers.push({
@@ -690,7 +690,7 @@ class TetherGame extends Gamegui {
       this.handleChooseCardFromAdriftConnect(e);
     adriftCards.forEach((card) => {
       if (card instanceof HTMLElement) {
-        if (this.cardIsPlayable(card)) {
+        if (this.isCardPlayable(card)) {
           card.classList.add('card--selectable');
           card.addEventListener('click', connectFromAdriftHandler);
           this.eventHandlers.push({

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -295,7 +295,7 @@ class TetherGame extends Gamegui {
           'connect-astronauts-button',
           _('Connect Astronauts'),
           () => {
-            this.highlightPlayableAstronauts('initial');
+            this.highlightPlayableAstronauts();
           }
         );
         if (this.playableCardNumbers.length === 0) {
@@ -650,7 +650,7 @@ class TetherGame extends Gamegui {
    * Called for each time the playable astronauts need to be highlighted during
    * the connect astronauts action.
    */
-  highlightPlayableAstronauts(call: 'initial' | 'further' = 'further') {
+  highlightPlayableAstronauts() {
     const handler = (e: Event) => this.handleChooseCardFromHandConnect(e);
     this.getCardElementsFromHand().forEach((card) => {
       if (card instanceof HTMLElement) {
@@ -666,7 +666,7 @@ class TetherGame extends Gamegui {
       }
     });
 
-    if (call === 'initial') {
+    if (this.clientState.status === 'choosingAction') {
       this.clientState = { status: 'connectingAstronautsInitial' };
       this.setClientState('client_connectAstronautInitial', {
         // @ts-expect-error

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -86,6 +86,8 @@ class TetherGame extends Gamegui {
 
   playerDirection: 'horizontal' | 'vertical' | null = null;
 
+  cardMap: Record<string, string> = {};
+
   playableCardNumbers: string[] = [];
 
   /** See {@link BGA.Gamegui} for more information. */
@@ -252,6 +254,21 @@ class TetherGame extends Gamegui {
   ///////////////////////////////////////////////////
   //// Game & client states
 
+  generateCardMap() {
+    for (const cardId in this.gameStateTurnStart.hand) {
+      const lowNum = this.gameStateTurnStart.hand[cardId]!.type_arg;
+      this.cardMap[lowNum] = cardId;
+      const numReversed = lowNum.split('').reverse().join('');
+      this.cardMap[numReversed] = cardId;
+    }
+    for (const cardId in this.gameStateTurnStart.adrift) {
+      const lowNum = this.gameStateTurnStart.adrift[cardId]!.cardNum;
+      this.cardMap[lowNum] = cardId;
+      const numReversed = lowNum.split('').reverse().join('');
+      this.cardMap[numReversed] = cardId;
+    }
+  }
+
   /** See {@link BGA.Gamegui#onEnteringState} for more information. */
   override onEnteringState(
     ...[stateName, state]: BGA.GameStateTuple<['name', 'state']>
@@ -261,6 +278,7 @@ class TetherGame extends Gamegui {
     switch (stateName) {
       case 'playerTurn':
         this.clientState = { status: 'choosingAction' };
+        this.generateCardMap();
         this.playableCardNumbers = (state.args['_private'] as string[]) || [];
         break;
       default:

--- a/tethergame.js
+++ b/tethergame.js
@@ -154,7 +154,24 @@ define("generateGroupUI", ["require", "exports"], function (require, exports) {
         return boardSpaces;
     }
 });
-define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connectCardToGroup", "generateGroupUI", "dojo", "ebg/counter"], function (require, exports, Gamegui, connectCardToGroup_1, generateGroupUI_1, dojo_1) {
+define("getConnectingNumbers", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.getConnectingNumbers = getConnectingNumbers;
+    function getConnectingNumbers(num) {
+        if (num.length !== 2) {
+            throw new Error('the number string should be exactly 2 characters long');
+        }
+        var parsedNum = parseInt(num);
+        if (parsedNum < 1 || parsedNum > 98) {
+            throw new Error('the number must be between 01 and 98');
+        }
+        var decremented = (parsedNum - 1).toString().padStart(2, '0');
+        var incremented = (parsedNum + 1).toString().padStart(2, '0');
+        return [decremented, incremented];
+    }
+});
+define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connectCardToGroup", "generateGroupUI", "getConnectingNumbers", "dojo", "ebg/counter"], function (require, exports, Gamegui, connectCardToGroup_1, generateGroupUI_1, getConnectingNumbers_1, dojo_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var TetherGame = (function (_super) {
@@ -338,8 +355,6 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
             switch (stateName) {
                 case 'playerTurn':
                     this.clientState = { status: 'choosingAction' };
-                    this.generateCardMap();
-                    this.playableCardNumbers = state.args['_private'] || [];
                     break;
                 default:
                     break;
@@ -365,7 +380,28 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                 return;
             switch (stateName) {
                 case 'playerTurn':
-                    this.playableCardNumbers = args['_private'] || [];
+                    this.generateCardMap();
+                    var playableCardNums = [];
+                    for (var cardId in this.gameStateTurnStart.hand) {
+                        var lowNum = this.gameStateTurnStart.hand[cardId].type_arg;
+                        for (var _e = 0, _f = (0, getConnectingNumbers_1.getConnectingNumbers)(lowNum); _e < _f.length; _e++) {
+                            var possibleConnectNum = _f[_e];
+                            if (this.cardMap[possibleConnectNum]) {
+                                playableCardNums.push(lowNum);
+                                break;
+                            }
+                        }
+                        var numReversed_1 = lowNum.split('').reverse().join('');
+                        for (var _g = 0, _h = (0, getConnectingNumbers_1.getConnectingNumbers)(numReversed_1); _g < _h.length; _g++) {
+                            var possibleConnectNum = _h[_g];
+                            if (this.cardMap[possibleConnectNum]) {
+                                playableCardNums.push(numReversed_1);
+                                break;
+                            }
+                        }
+                    }
+                    console.log(playableCardNums);
+                    this.playableCardNumbers = playableCardNums;
                     this.addActionButton('connect-astronauts-button', _('Connect Astronauts'), function () {
                         _this.highlightPlayableAstronauts();
                     });
@@ -399,7 +435,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                     if (this.clientState.status !== 'choosingCardSideToPlay') {
                         throw new Error('cardForConnecting not in correct state for this call');
                     }
-                    var _e = this.clientState.card, first_1 = _e.first, number = _e.number, numReversed = _e.numReversed;
+                    var _j = this.clientState.card, first_1 = _j.first, number = _j.number, numReversed = _j.numReversed;
                     this.addActionButton('play-upright-button', _("Play card as ".concat(number)), function () {
                         _this.handleChooseCardToPlay({
                             first: first_1,


### PR DESCRIPTION
## Overview

- Resolves #27 
- Previously, the BE would give a list of all card numbers that could be connected to at least one other card, and this was used as a constant to decide what cards to highlight.
  - This would highlight and allow invalid cards to be connected together.
  - This PR adds logic to the FE to calculate the initially playable cards and updates what cards to highlight based on the currently played card.