### PR TITLE
refactor: use id instead of number for groups

### DIFF
--- a/dbmodel.sql
+++ b/dbmodel.sql
@@ -26,10 +26,10 @@ CREATE TABLE IF NOT EXISTS `card` (
   `card_type_arg` varchar(11) NOT NULL,
   -- `card_location`
   -- deck, hand, adrift, board
-  `card_location` varchar(16) NOT NULL,
+  `card_location` varchar(10) NOT NULL,
   -- `card_location_arg`
   -- if hand, player_id of the hand. if board, the group number and x/y coord in the format group_x_y
-  `card_location_arg` varchar(11) NOT NULL,
+  `card_location_arg` varchar(16) NOT NULL,
   -- `scored_at`
   -- the size threshold at which the card was last scored. Can be empty, 6, 10, or 14.
   `scored_at` int(10) unsigned,

--- a/source/client/connectCardToGroup.ts
+++ b/source/client/connectCardToGroup.ts
@@ -7,7 +7,7 @@ export interface Card {
 }
 
 export interface Group {
-  number: number; // incremental number to keep track of the groups
+  id: string;
   cards: {
     [x: number]: (null | Card)[];
   };

--- a/source/client/connectGroups.spec.ts
+++ b/source/client/connectGroups.spec.ts
@@ -6,7 +6,7 @@ import * as assert from 'uvu/assert';
 // #region vertical connect
 test('can connect two simple groups vertically', () => {
   const group1: Group = {
-    number: 1,
+    id: '81ff95',
     cards: {
       0: [
         { id: '1', lowNum: '01', uprightFor: 'vertical' },
@@ -15,7 +15,7 @@ test('can connect two simple groups vertically', () => {
     },
   };
   const group2: Group = {
-    number: 2,
+    id: 'cf306b',
     cards: {
       0: [
         { id: '3', lowNum: '03', uprightFor: 'vertical' },
@@ -45,7 +45,7 @@ test('can connect two simple groups vertically', () => {
   });
 
   assert.equal(result, {
-    number: 1,
+    id: '81ff95',
     cards: {
       0: [
         { id: '1', lowNum: '01', uprightFor: 'vertical' },
@@ -58,7 +58,7 @@ test('can connect two simple groups vertically', () => {
 });
 test('can vertically connect two groups of different width with negative offset', () => {
   const group1: Group = {
-    number: 1,
+    id: 'cf306b',
     cards: {
       0: [
         null,
@@ -90,7 +90,7 @@ test('can vertically connect two groups of different width with negative offset'
     },
   };
   const group2: Group = {
-    number: 2,
+    id: '81ff95',
     cards: {
       0: [{ id: '69', lowNum: '69', uprightFor: 'vertical' }, null],
       1: [
@@ -121,7 +121,7 @@ test('can vertically connect two groups of different width with negative offset'
   });
 
   assert.equal(result, {
-    number: 1,
+    id: 'cf306b',
     cards: {
       0: [
         null,
@@ -169,7 +169,7 @@ test('can vertically connect two groups of different width with negative offset'
 
 test('can connect two groups vertically, with one extending past the beginning of the other, and either connection point can be used', () => {
   const group1: Group = {
-    number: 1,
+    id: 'cf306b',
     cards: {
       0: [
         { id: '57', lowNum: '57', uprightFor: 'vertical' },
@@ -185,7 +185,7 @@ test('can connect two groups vertically, with one extending past the beginning o
   };
 
   const group2: Group = {
-    number: 2,
+    id: '81ff95',
     cards: {
       0: [
         { id: '66', lowNum: '66', uprightFor: 'vertical' },
@@ -216,7 +216,7 @@ test('can connect two groups vertically, with one extending past the beginning o
     orientation: 'vertical',
   });
   const expected = {
-    number: 1,
+    id: 'cf306b',
     cards: {
       0: [
         { id: '66', lowNum: '66', uprightFor: 'vertical' },
@@ -266,14 +266,14 @@ test('can connect two groups vertically, with one extending past the beginning o
 // #region horizontal connect
 test('can connect two simple groups horizontally successfully', () => {
   const group1: Group = {
-    number: 1,
+    id: 'cf306b',
     cards: {
       0: [{ id: '58', lowNum: '58', uprightFor: 'horizontal' }],
       1: [{ id: '57', lowNum: '57', uprightFor: 'horizontal' }],
     },
   };
   const group2: Group = {
-    number: 2,
+    id: '81ff95',
     cards: {
       0: [{ id: '6', lowNum: '06', uprightFor: 'vertical' }],
       1: [{ id: '59', lowNum: '59', uprightFor: 'horizontal' }],
@@ -301,7 +301,7 @@ test('can connect two simple groups horizontally successfully', () => {
   });
 
   assert.equal(result, {
-    number: 1,
+    id: 'cf306b',
     cards: {
       0: [{ id: '6', lowNum: '06', uprightFor: 'vertical' }],
       1: [{ id: '59', lowNum: '59', uprightFor: 'horizontal' }],
@@ -313,7 +313,7 @@ test('can connect two simple groups horizontally successfully', () => {
 
 test('can successfully connect two groups horizontally that are somewhat complex', () => {
   const group1: Group = {
-    number: 1,
+    id: '81ff95',
     cards: {
       0: [
         {
@@ -338,7 +338,7 @@ test('can successfully connect two groups horizontally that are somewhat complex
     },
   };
   const group2: Group = {
-    number: 2,
+    id: 'cf306b',
     cards: {
       0: [
         {
@@ -383,7 +383,7 @@ test('can successfully connect two groups horizontally that are somewhat complex
   });
 
   assert.equal(res, {
-    number: 1,
+    id: '81ff95',
     cards: {
       0: [
         {
@@ -435,7 +435,7 @@ test('can successfully connect two groups horizontally that are somewhat complex
 
 test('can connect groups where cards replace null/blank spaces, with the second group extending further than the end of the first group from the vertical perspective', () => {
   const group1: Group = {
-    number: 3,
+    id: 'cf306b',
     cards: {
       0: [
         { id: '28', lowNum: '28', uprightFor: 'horizontal' },
@@ -449,7 +449,7 @@ test('can connect groups where cards replace null/blank spaces, with the second 
     },
   };
   const group2: Group = {
-    number: 2,
+    id: '81ff95',
     cards: {
       0: [
         {
@@ -511,7 +511,7 @@ test('can connect groups where cards replace null/blank spaces, with the second 
   });
 
   const expected = {
-    number: 2,
+    id: 'cf306b',
     cards: {
       0: [
         { id: '28', lowNum: '28', uprightFor: 'horizontal' },
@@ -570,7 +570,7 @@ test('can connect groups where cards replace null/blank spaces, with the second 
 
 test("can connect two groups horizontally, replacing blank spaces, extending a new starting column from the vertical player's perspective (new column from the horizontal perspective)", () => {
   const connectGreater: Group = {
-    number: 3,
+    id: '81ff95',
     cards: {
       0: [
         { id: '29', lowNum: '29', uprightFor: 'horizontal' },
@@ -584,7 +584,7 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
     },
   };
   const connectLesser: Group = {
-    number: 2,
+    id: 'cf306b',
     cards: {
       0: [
         null,
@@ -646,7 +646,7 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
   });
 
   assert.equal(result, {
-    number: 2,
+    id: '81ff95',
     cards: {
       0: [
         null,

--- a/source/client/connectGroups.ts
+++ b/source/client/connectGroups.ts
@@ -59,8 +59,6 @@ export function connectGroups({
     orientation,
   });
 
-  const newGroupId = group1.group.id;
-
   // We will first connect the two groups at a relative position of 0,0 and 0,1
   // for a vertical connection and 0,0 and 1,0 for a horizontal connection.
   // We will then fill in the rest of each group around this relative position
@@ -124,7 +122,7 @@ export function connectGroups({
 
   // loop over the temporary combined group now using the xOffset to create a new group
   const newGroup: Group = {
-    id: newGroupId,
+    id: group1.group.id,
     cards: {},
   };
   for (const oldX of Object.keys(temporaryCombinedGroup)) {

--- a/source/client/connectGroups.ts
+++ b/source/client/connectGroups.ts
@@ -59,7 +59,7 @@ export function connectGroups({
     orientation,
   });
 
-  const newGroupNum = Math.min(group1.group.number, group2.group.number);
+  const newGroupId = group1.group.id;
 
   // We will first connect the two groups at a relative position of 0,0 and 0,1
   // for a vertical connection and 0,0 and 1,0 for a horizontal connection.
@@ -124,7 +124,7 @@ export function connectGroups({
 
   // loop over the temporary combined group now using the xOffset to create a new group
   const newGroup: Group = {
-    number: newGroupNum,
+    id: newGroupId,
     cards: {},
   };
   for (const oldX of Object.keys(temporaryCombinedGroup)) {

--- a/source/client/generateGroupUI.ts
+++ b/source/client/generateGroupUI.ts
@@ -16,7 +16,7 @@ export function generateGroupUI(group: Group) {
   const numCols = Object.keys(group.cards).length;
   const numRows = group.cards[0]?.length;
   if (!numRows) {
-    throw new Error(`somehow there are no rows in group: ${group.number}`);
+    throw new Error(`somehow there are no rows in group: ${group.id}`);
   }
   const boardSpaces: GroupUI = [];
 

--- a/tethergame.js
+++ b/tethergame.js
@@ -231,7 +231,6 @@ define("connectGroups", ["require", "exports"], function (require, exports) {
             group2: group2,
             orientation: orientation,
         }), groupFrom = _m.groupFrom, groupTo = _m.groupTo;
-        var newGroupId = group1.group.id;
         var relativeToY = orientation === 'vertical' ? 1 : 0;
         var relativeFromX = orientation === 'horizontal' ? 1 : 0;
         var temporaryCombinedGroup = {};
@@ -321,7 +320,7 @@ define("connectGroups", ["require", "exports"], function (require, exports) {
         });
         yOffset = yOffset * -1;
         var newGroup = {
-            id: newGroupId,
+            id: group1.group.id,
             cards: {},
         };
         try {


### PR DESCRIPTION
## Overview

There was a bug that was happening with the previous system of using incremental numbers. We are now using truncated UUIDs, which should remove the chance of this happening. Some logic has been simplified as well.