### PR TITLE
Make astronauts connect high to low, top to bottom for the vertical player

### DIFF
--- a/source/client/connectCardToGroup.spec.ts
+++ b/source/client/connectCardToGroup.spec.ts
@@ -172,10 +172,10 @@ test('should extend rows correctly when connecting a card horizontally at the be
   const group: Group = {
     id: '2',
     cards: {
-      0: [{ id: '3', lowNum: '03', uprightFor: 'horizontal' }, null],
+      0: [null, { id: '3', lowNum: '03', uprightFor: 'horizontal' }],
       1: [
-        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
         { id: '12', lowNum: '12', uprightFor: 'horizontal' },
+        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
       ],
     },
   };
@@ -193,38 +193,38 @@ test('should extend rows correctly when connecting a card horizontally at the be
         lowNum: '02',
         uprightFor: 'horizontal',
       },
-      y: 0,
       x: 1,
+      y: 1,
     },
   });
   assert.equal(group, {
     id: '2',
     cards: {
-      0: [{ id: '3', lowNum: '03', uprightFor: 'horizontal' }, null],
+      0: [null, { id: '3', lowNum: '03', uprightFor: 'horizontal' }],
       1: [
-        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
         { id: '12', lowNum: '12', uprightFor: 'horizontal' },
+        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
       ],
-      2: [{ id: '1', lowNum: '01', uprightFor: 'horizontal' }, null],
+      2: [null, { id: '1', lowNum: '01', uprightFor: 'horizontal' }],
     },
   });
 });
 
 test('should extend rows correctly when connecting a card horizontally at the end', () => {
   // horizontal player view:
-  // 12
   // 02 03
+  // 12
   //
   // vertical player view:
-  // 30 20
   //    21
+  // 30 20
   const group: Group = {
     id: '2',
     cards: {
-      0: [{ id: '3', lowNum: '03', uprightFor: 'horizontal' }, null],
+      0: [null, { id: '3', lowNum: '03', uprightFor: 'horizontal' }],
       1: [
-        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
         { id: '12', lowNum: '12', uprightFor: 'horizontal' },
+        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
       ],
     },
   };
@@ -243,17 +243,17 @@ test('should extend rows correctly when connecting a card horizontally at the en
         uprightFor: 'horizontal',
       },
       x: 0,
-      y: 0,
+      y: 1,
     },
   });
   assert.equal(group, {
     id: '2',
     cards: {
-      0: [{ id: '4', lowNum: '04', uprightFor: 'horizontal' }, null],
-      1: [{ id: '3', lowNum: '03', uprightFor: 'horizontal' }, null],
+      0: [null, { id: '4', lowNum: '04', uprightFor: 'horizontal' }],
+      1: [null, { id: '3', lowNum: '03', uprightFor: 'horizontal' }],
       2: [
-        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
         { id: '12', lowNum: '12', uprightFor: 'horizontal' },
+        { id: '2', lowNum: '02', uprightFor: 'horizontal' },
       ],
     },
   });
@@ -261,21 +261,21 @@ test('should extend rows correctly when connecting a card horizontally at the en
 
 test('can connect a card of a different orientation horizontally to a group of mixed orientations, with the card replacing a blank space (null)', () => {
   // for vertical:
-  // 17 07
   //    08 97
+  // 17 07
 
   // for horizontal:
-  // 79 80
   //    70 71
+  // 79 80
   const group: Group = {
     id: '2',
     cards: {
-      0: [{ id: '17', lowNum: '17', uprightFor: 'vertical' }, null],
+      0: [null, { id: '17', lowNum: '17', uprightFor: 'vertical' }],
       1: [
-        { id: '07', lowNum: '07', uprightFor: 'vertical' },
         { id: '08', lowNum: '08', uprightFor: 'vertical' },
+        { id: '07', lowNum: '07', uprightFor: 'vertical' },
       ],
-      2: [null, { id: '79', lowNum: '79', uprightFor: 'horizontal' }],
+      2: [{ id: '79', lowNum: '79', uprightFor: 'horizontal' }, null],
     },
   };
 
@@ -294,21 +294,21 @@ test('can connect a card of a different orientation horizontally to a group of m
         uprightFor: 'vertical',
       },
       x: 1,
-      y: 0,
+      y: 1,
     },
   });
 
   assert.equal(group, {
     id: '2',
     cards: {
-      0: [{ id: '17', lowNum: '17', uprightFor: 'vertical' }, null],
+      0: [null, { id: '17', lowNum: '17', uprightFor: 'vertical' }],
       1: [
-        { id: '07', lowNum: '07', uprightFor: 'vertical' },
         { id: '08', lowNum: '08', uprightFor: 'vertical' },
+        { id: '07', lowNum: '07', uprightFor: 'vertical' },
       ],
       2: [
-        { id: '69', lowNum: '69', uprightFor: 'horizontal' },
         { id: '79', lowNum: '79', uprightFor: 'horizontal' },
+        { id: '69', lowNum: '69', uprightFor: 'horizontal' },
       ],
     },
   });
@@ -316,24 +316,24 @@ test('can connect a card of a different orientation horizontally to a group of m
 
 test('can connect a card horizontally and fill in blank spaces correctly', () => {
   // for vertical:
-  // 20
-  // 21
-  // 22
   // 23
+  // 22
+  // 21
+  // 20
 
   // for horizontal:
-  // 32
-  // 22
-  // 12
   // 02
+  // 12
+  // 22
+  // 32
   const group: Group = {
     id: '2',
     cards: {
       0: [
-        { id: '02', lowNum: '02', uprightFor: 'horizontal' },
-        { id: '12', lowNum: '12', uprightFor: 'horizontal' },
-        { id: '22', lowNum: '22', uprightFor: 'vertical' },
         { id: '23', lowNum: '23', uprightFor: 'vertical' },
+        { id: '22', lowNum: '22', uprightFor: 'vertical' },
+        { id: '12', lowNum: '12', uprightFor: 'horizontal' },
+        { id: '02', lowNum: '02', uprightFor: 'horizontal' },
       ],
     },
   };
@@ -353,19 +353,19 @@ test('can connect a card horizontally and fill in blank spaces correctly', () =>
         uprightFor: 'vertical',
       },
       x: 0,
-      y: 3,
+      y: 0,
     },
   });
 
   assert.equal(group, {
     id: '2',
     cards: {
-      0: [null, null, null, { id: '33', lowNum: '33', uprightFor: 'vertical' }],
+      0: [{ id: '33', lowNum: '33', uprightFor: 'vertical' }, null, null, null],
       1: [
-        { id: '02', lowNum: '02', uprightFor: 'horizontal' },
-        { id: '12', lowNum: '12', uprightFor: 'horizontal' },
-        { id: '22', lowNum: '22', uprightFor: 'vertical' },
         { id: '23', lowNum: '23', uprightFor: 'vertical' },
+        { id: '22', lowNum: '22', uprightFor: 'vertical' },
+        { id: '12', lowNum: '12', uprightFor: 'horizontal' },
+        { id: '02', lowNum: '02', uprightFor: 'horizontal' },
       ],
     },
   });
@@ -376,23 +376,23 @@ test('can connect a card that fills in a blank space (null), and the card is con
     id: '2',
     cards: {
       0: [
-        null,
-        null,
-        { id: '33', lowNum: '33', uprightFor: 'vertical' },
         { id: '34', lowNum: '34', uprightFor: 'vertical' },
-      ],
-      1: [null, null, { id: '23', lowNum: '23', uprightFor: 'vertical' }, null],
-      2: [
-        { id: '11', lowNum: '11', uprightFor: 'vertical' },
-        { id: '12', lowNum: '12', uprightFor: 'vertical' },
-        { id: '13', lowNum: '13', uprightFor: 'vertical' },
+        { id: '33', lowNum: '33', uprightFor: 'vertical' },
         null,
+        null,
+      ],
+      1: [null, { id: '23', lowNum: '23', uprightFor: 'vertical' }, null, null],
+      2: [
+        null,
+        { id: '13', lowNum: '13', uprightFor: 'vertical' },
+        { id: '12', lowNum: '12', uprightFor: 'vertical' },
+        { id: '11', lowNum: '11', uprightFor: 'vertical' },
       ],
       3: [
-        { id: '01', lowNum: '01', uprightFor: 'vertical' },
-        { id: '02', lowNum: '02', uprightFor: 'vertical' },
-        { id: '03', lowNum: '03', uprightFor: 'vertical' },
         null,
+        { id: '03', lowNum: '03', uprightFor: 'vertical' },
+        { id: '02', lowNum: '02', uprightFor: 'vertical' },
+        { id: '01', lowNum: '01', uprightFor: 'vertical' },
       ],
     },
   };
@@ -412,7 +412,7 @@ test('can connect a card that fills in a blank space (null), and the card is con
         uprightFor: 'vertical',
       },
       x: 2,
-      y: 1,
+      y: 2,
     },
   });
 
@@ -420,28 +420,28 @@ test('can connect a card that fills in a blank space (null), and the card is con
     id: '2',
     cards: {
       0: [
-        null,
-        null,
-        { id: '33', lowNum: '33', uprightFor: 'vertical' },
         { id: '34', lowNum: '34', uprightFor: 'vertical' },
+        { id: '33', lowNum: '33', uprightFor: 'vertical' },
+        null,
+        null,
       ],
       1: [
         null,
-        { id: '22', lowNum: '22', uprightFor: 'vertical' },
         { id: '23', lowNum: '23', uprightFor: 'vertical' },
+        { id: '22', lowNum: '22', uprightFor: 'vertical' },
         null,
       ],
       2: [
-        { id: '11', lowNum: '11', uprightFor: 'vertical' },
-        { id: '12', lowNum: '12', uprightFor: 'vertical' },
-        { id: '13', lowNum: '13', uprightFor: 'vertical' },
         null,
+        { id: '13', lowNum: '13', uprightFor: 'vertical' },
+        { id: '12', lowNum: '12', uprightFor: 'vertical' },
+        { id: '11', lowNum: '11', uprightFor: 'vertical' },
       ],
       3: [
-        { id: '01', lowNum: '01', uprightFor: 'vertical' },
-        { id: '02', lowNum: '02', uprightFor: 'vertical' },
-        { id: '03', lowNum: '03', uprightFor: 'vertical' },
         null,
+        { id: '03', lowNum: '03', uprightFor: 'vertical' },
+        { id: '02', lowNum: '02', uprightFor: 'vertical' },
+        { id: '01', lowNum: '01', uprightFor: 'vertical' },
       ],
     },
   });

--- a/source/client/connectCardToGroup.spec.ts
+++ b/source/client/connectCardToGroup.spec.ts
@@ -8,10 +8,10 @@ test('should extend columns correctly when connecting a card vertically at the e
     id: '2',
     cards: {
       0: [
-        { id: '1', lowNum: '01', uprightFor: 'vertical' },
         { id: '2', lowNum: '02', uprightFor: 'vertical' },
+        { id: '1', lowNum: '01', uprightFor: 'vertical' },
       ],
-      1: [null, { id: '19', lowNum: '19', uprightFor: 'horizontal' }],
+      1: [{ id: '19', lowNum: '19', uprightFor: 'horizontal' }, null],
     },
   };
   connectCardToGroup({
@@ -29,7 +29,7 @@ test('should extend columns correctly when connecting a card vertically at the e
         uprightFor: 'vertical',
       },
       x: 0,
-      y: 1,
+      y: 0,
     },
   });
 
@@ -37,9 +37,9 @@ test('should extend columns correctly when connecting a card vertically at the e
     id: '2',
     cards: {
       0: [
-        { id: '1', lowNum: '01', uprightFor: 'vertical' },
-        { id: '2', lowNum: '02', uprightFor: 'vertical' },
         { id: '3', lowNum: '03', uprightFor: 'vertical' },
+        { id: '2', lowNum: '02', uprightFor: 'vertical' },
+        { id: '1', lowNum: '01', uprightFor: 'vertical' },
       ],
       1: [null, { id: '19', lowNum: '19', uprightFor: 'horizontal' }, null],
     },
@@ -51,10 +51,10 @@ test('should extend columns correctly when connecting a card vertically at the b
     id: '2',
     cards: {
       0: [
-        { id: '2', lowNum: '02', uprightFor: 'vertical' },
         { id: '3', lowNum: '03', uprightFor: 'vertical' },
+        { id: '2', lowNum: '02', uprightFor: 'vertical' },
       ],
-      1: [null, { id: '29', lowNum: '29', uprightFor: 'horizontal' }],
+      1: [{ id: '29', lowNum: '29', uprightFor: 'horizontal' }, null],
     },
   };
   connectCardToGroup({
@@ -72,47 +72,47 @@ test('should extend columns correctly when connecting a card vertically at the b
         uprightFor: 'vertical',
       },
       x: 0,
-      y: 0,
+      y: 1,
     },
   });
   assert.equal(group, {
     id: '2',
     cards: {
       0: [
-        { id: '1', lowNum: '01', uprightFor: 'vertical' },
-        { id: '2', lowNum: '02', uprightFor: 'vertical' },
         { id: '3', lowNum: '03', uprightFor: 'vertical' },
+        { id: '2', lowNum: '02', uprightFor: 'vertical' },
+        { id: '1', lowNum: '01', uprightFor: 'vertical' },
       ],
-      1: [null, null, { id: '29', lowNum: '29', uprightFor: 'horizontal' }],
+      1: [{ id: '29', lowNum: '29', uprightFor: 'horizontal' }, null, null],
     },
   });
 });
 
 test('can connect a card of a different orientation vertically to a group of mixed orientations, with the card replacing a blank space (null)', () => {
   // for vertical:
-  //    39
-  // 50 40
   // 51
+  // 50 40
+  //    39
   const group: Group = {
     id: '2',
     cards: {
       0: [
-        null,
-        {
-          id: '05',
-          lowNum: '05',
-          uprightFor: 'horizontal',
-        },
         {
           id: '15',
           lowNum: '15',
           uprightFor: 'horizontal',
         },
+        {
+          id: '05',
+          lowNum: '05',
+          uprightFor: 'horizontal',
+        },
+        null,
       ],
       1: [
-        { id: '39', lowNum: '39', uprightFor: 'vertical' },
-        { id: '04', lowNum: '04', uprightFor: 'horizontal' },
         null,
+        { id: '04', lowNum: '04', uprightFor: 'horizontal' },
+        { id: '39', lowNum: '39', uprightFor: 'vertical' },
       ],
     },
   };
@@ -141,9 +141,9 @@ test('can connect a card of a different orientation vertically to a group of mix
     cards: {
       0: [
         {
-          id: '49',
-          lowNum: '49',
-          uprightFor: 'vertical',
+          id: '15',
+          lowNum: '15',
+          uprightFor: 'horizontal',
         },
         {
           id: '05',
@@ -151,15 +151,15 @@ test('can connect a card of a different orientation vertically to a group of mix
           uprightFor: 'horizontal',
         },
         {
-          id: '15',
-          lowNum: '15',
-          uprightFor: 'horizontal',
+          id: '49',
+          lowNum: '49',
+          uprightFor: 'vertical',
         },
       ],
       1: [
-        { id: '39', lowNum: '39', uprightFor: 'vertical' },
-        { id: '04', lowNum: '04', uprightFor: 'horizontal' },
         null,
+        { id: '04', lowNum: '04', uprightFor: 'horizontal' },
+        { id: '39', lowNum: '39', uprightFor: 'vertical' },
       ],
     },
   });

--- a/source/client/connectCardToGroup.ts
+++ b/source/client/connectCardToGroup.ts
@@ -59,7 +59,7 @@ export function connectCardToGroup({
         );
       }
       const itemToAdd = i === connection.x ? card : null;
-      const connectAfter = cardNumShown > connectionCardNumShown;
+      const connectAfter = connectionCardNumShown > cardNumShown;
       // We want to replace a null if it is present where we are inserting
       // the new card - it is an empty space that we can fill.
       const itemAdjacentToConnectionIndex =

--- a/source/client/connectGroups.spec.ts
+++ b/source/client/connectGroups.spec.ts
@@ -328,49 +328,19 @@ test('can successfully connect two groups horizontally that are somewhat complex
     id: '81ff95',
     cards: {
       0: [
-        {
-          id: '58',
-          lowNum: '58',
-          uprightFor: 'horizontal',
-        },
-        {
-          id: '68',
-          lowNum: '68',
-          uprightFor: 'horizontal',
-        },
+        { id: '68', lowNum: '68', uprightFor: 'horizontal' },
+        { id: '58', lowNum: '58', uprightFor: 'horizontal' },
       ],
-      1: [
-        {
-          id: '57',
-          lowNum: '57',
-          uprightFor: 'horizontal',
-        },
-        null,
-      ],
+      1: [null, { id: '57', lowNum: '57', uprightFor: 'horizontal' }],
     },
   };
   const group2: Group = {
     id: 'cf306b',
     cards: {
-      0: [
-        {
-          id: '5',
-          lowNum: '05',
-          uprightFor: 'vertical',
-        },
-        null,
-      ],
+      0: [null, { id: '5', lowNum: '05', uprightFor: 'vertical' }],
       1: [
-        {
-          id: '49',
-          lowNum: '49',
-          uprightFor: 'horizontal',
-        },
-        {
-          id: '59',
-          lowNum: '59',
-          uprightFor: 'horizontal',
-        },
+        { id: '59', lowNum: '59', uprightFor: 'horizontal' },
+        { id: '49', lowNum: '49', uprightFor: 'horizontal' },
       ],
     },
   };
@@ -380,7 +350,7 @@ test('can successfully connect two groups horizontally that are somewhat complex
       connection: {
         card: { id: '58', lowNum: '58', uprightFor: 'horizontal' },
         x: 0,
-        y: 0,
+        y: 1,
       },
     },
     group2: {
@@ -388,7 +358,7 @@ test('can successfully connect two groups horizontally that are somewhat complex
       connection: {
         card: { id: '59', lowNum: '59', uprightFor: 'horizontal' },
         x: 1,
-        y: 1,
+        y: 0,
       },
     },
     orientation: 'horizontal',
@@ -397,50 +367,18 @@ test('can successfully connect two groups horizontally that are somewhat complex
   assert.equal(res, {
     id: '81ff95',
     cards: {
-      0: [
-        {
-          id: '5',
-          lowNum: '05',
-          uprightFor: 'vertical',
-        },
-        null,
-        null,
-      ],
+      0: [null, null, { id: '5', lowNum: '05', uprightFor: 'vertical' }],
       1: [
-        {
-          id: '49',
-          lowNum: '49',
-          uprightFor: 'horizontal',
-        },
-        {
-          id: '59',
-          lowNum: '59',
-          uprightFor: 'horizontal',
-        },
         null,
+        { id: '59', lowNum: '59', uprightFor: 'horizontal' },
+        { id: '49', lowNum: '49', uprightFor: 'horizontal' },
       ],
       2: [
-        null,
-        {
-          id: '58',
-          lowNum: '58',
-          uprightFor: 'horizontal',
-        },
-        {
-          id: '68',
-          lowNum: '68',
-          uprightFor: 'horizontal',
-        },
-      ],
-      3: [
-        null,
-        {
-          id: '57',
-          lowNum: '57',
-          uprightFor: 'horizontal',
-        },
+        { id: '68', lowNum: '68', uprightFor: 'horizontal' },
+        { id: '58', lowNum: '58', uprightFor: 'horizontal' },
         null,
       ],
+      3: [null, { id: '57', lowNum: '57', uprightFor: 'horizontal' }, null],
     },
   });
 });
@@ -450,13 +388,13 @@ test('can connect groups where cards replace null/blank spaces, with the second 
     id: 'cf306b',
     cards: {
       0: [
-        { id: '28', lowNum: '28', uprightFor: 'horizontal' },
         { id: '38', lowNum: '38', uprightFor: 'horizontal' },
+        { id: '28', lowNum: '28', uprightFor: 'horizontal' },
       ],
-      1: [{ id: '27', lowNum: '27', uprightFor: 'horizontal' }, null],
+      1: [null, { id: '27', lowNum: '27', uprightFor: 'horizontal' }],
       2: [
-        { id: '26', lowNum: '26', uprightFor: 'horizontal' },
         { id: '36', lowNum: '36', uprightFor: 'horizontal' },
+        { id: '26', lowNum: '26', uprightFor: 'horizontal' },
       ],
     },
   };
@@ -464,33 +402,11 @@ test('can connect groups where cards replace null/blank spaces, with the second 
     id: '81ff95',
     cards: {
       0: [
-        {
-          id: '37',
-          lowNum: '37',
-          uprightFor: 'horizontal',
-        },
-        {
-          id: '47',
-          lowNum: '47',
-          uprightFor: 'horizontal',
-        },
+        { id: '47', lowNum: '47', uprightFor: 'horizontal' },
+        { id: '37', lowNum: '37', uprightFor: 'horizontal' },
       ],
-      1: [
-        null,
-        {
-          id: '46',
-          lowNum: '46',
-          uprightFor: 'horizontal',
-        },
-      ],
-      2: [
-        null,
-        {
-          id: '45',
-          lowNum: '45',
-          uprightFor: 'horizontal',
-        },
-      ],
+      1: [{ id: '46', lowNum: '46', uprightFor: 'horizontal' }, null],
+      2: [{ id: '45', lowNum: '45', uprightFor: 'horizontal' }, null],
     },
   };
 
@@ -504,7 +420,7 @@ test('can connect groups where cards replace null/blank spaces, with the second 
           uprightFor: 'horizontal',
         },
         x: 2,
-        y: 1,
+        y: 0,
       },
     },
     group2: {
@@ -516,7 +432,7 @@ test('can connect groups where cards replace null/blank spaces, with the second 
           uprightFor: 'horizontal',
         },
         x: 0,
-        y: 0,
+        y: 1,
       },
     },
     orientation: 'horizontal',
@@ -526,25 +442,21 @@ test('can connect groups where cards replace null/blank spaces, with the second 
     id: 'cf306b',
     cards: {
       0: [
-        { id: '28', lowNum: '28', uprightFor: 'horizontal' },
-        {
-          id: '38',
-          lowNum: '38',
-          uprightFor: 'horizontal',
-        },
         null,
+        { id: '38', lowNum: '38', uprightFor: 'horizontal' },
+        { id: '28', lowNum: '28', uprightFor: 'horizontal' },
       ],
       1: [
-        { id: '27', lowNum: '27', uprightFor: 'horizontal' },
-        { id: '37', lowNum: '37', uprightFor: 'horizontal' },
         { id: '47', lowNum: '47', uprightFor: 'horizontal' },
+        { id: '37', lowNum: '37', uprightFor: 'horizontal' },
+        { id: '27', lowNum: '27', uprightFor: 'horizontal' },
       ],
       2: [
-        { id: '26', lowNum: '26', uprightFor: 'horizontal' },
-        { id: '36', lowNum: '36', uprightFor: 'horizontal' },
         { id: '46', lowNum: '46', uprightFor: 'horizontal' },
+        { id: '36', lowNum: '36', uprightFor: 'horizontal' },
+        { id: '26', lowNum: '26', uprightFor: 'horizontal' },
       ],
-      3: [null, null, { id: '45', lowNum: '45', uprightFor: 'horizontal' }],
+      3: [{ id: '45', lowNum: '45', uprightFor: 'horizontal' }, null, null],
     },
   };
 
@@ -561,7 +473,7 @@ test('can connect groups where cards replace null/blank spaces, with the second 
           uprightFor: 'horizontal',
         },
         x: 0,
-        y: 1,
+        y: 0,
       },
     },
     group2: {
@@ -573,11 +485,13 @@ test('can connect groups where cards replace null/blank spaces, with the second 
           uprightFor: 'horizontal',
         },
         x: 0,
-        y: 0,
+        y: 1,
       },
     },
     orientation: 'horizontal',
   });
+
+  assert.equal(result2, expected);
 });
 
 test("can connect two groups horizontally, replacing blank spaces, extending a new starting column from the vertical player's perspective (new column from the horizontal perspective)", () => {
@@ -585,13 +499,13 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
     id: '81ff95',
     cards: {
       0: [
-        { id: '29', lowNum: '29', uprightFor: 'horizontal' },
         { id: '39', lowNum: '39', uprightFor: 'horizontal' },
+        { id: '29', lowNum: '29', uprightFor: 'horizontal' },
       ],
-      1: [{ id: '28', lowNum: '28', uprightFor: 'horizontal' }, null],
+      1: [null, { id: '28', lowNum: '28', uprightFor: 'horizontal' }],
       2: [
-        { id: '27', lowNum: '27', uprightFor: 'horizontal' },
         { id: '37', lowNum: '37', uprightFor: 'horizontal' },
+        { id: '27', lowNum: '27', uprightFor: 'horizontal' },
       ],
     },
   };
@@ -599,30 +513,30 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
     id: 'cf306b',
     cards: {
       0: [
-        null,
         {
           id: '05',
           lowNum: '05',
           uprightFor: 'vertical',
         },
+        null,
       ],
       1: [
-        null,
         {
           id: '49',
           lowNum: '49',
           uprightFor: 'horizontal',
         },
+        null,
       ],
       2: [
         {
-          id: '38',
-          lowNum: '38',
+          id: '48',
+          lowNum: '48',
           uprightFor: 'horizontal',
         },
         {
-          id: '48',
-          lowNum: '48',
+          id: '38',
+          lowNum: '38',
           uprightFor: 'horizontal',
         },
       ],
@@ -639,7 +553,7 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
           uprightFor: 'horizontal',
         },
         x: 0,
-        y: 1,
+        y: 0,
       },
     },
     group2: {
@@ -651,7 +565,7 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
           uprightFor: 'horizontal',
         },
         x: 2,
-        y: 0,
+        y: 1,
       },
     },
     orientation: 'horizontal',
@@ -660,33 +574,21 @@ test("can connect two groups horizontally, replacing blank spaces, extending a n
   assert.equal(result, {
     id: '81ff95',
     cards: {
-      0: [
-        null,
-        null,
-        {
-          id: '05',
-          lowNum: '05',
-          uprightFor: 'vertical',
-        },
-      ],
+      0: [{ id: '05', lowNum: '05', uprightFor: 'vertical' }, null, null],
       1: [
-        { id: '29', lowNum: '29', uprightFor: 'horizontal' },
-        { id: '39', lowNum: '39', uprightFor: 'horizontal' },
         { id: '49', lowNum: '49', uprightFor: 'horizontal' },
+        { id: '39', lowNum: '39', uprightFor: 'horizontal' },
+        { id: '29', lowNum: '29', uprightFor: 'horizontal' },
       ],
       2: [
-        { id: '28', lowNum: '28', uprightFor: 'horizontal' },
-        {
-          id: '38',
-          lowNum: '38',
-          uprightFor: 'horizontal',
-        },
         { id: '48', lowNum: '48', uprightFor: 'horizontal' },
+        { id: '38', lowNum: '38', uprightFor: 'horizontal' },
+        { id: '28', lowNum: '28', uprightFor: 'horizontal' },
       ],
       3: [
-        { id: '27', lowNum: '27', uprightFor: 'horizontal' },
-        { id: '37', lowNum: '37', uprightFor: 'horizontal' },
         null,
+        { id: '37', lowNum: '37', uprightFor: 'horizontal' },
+        { id: '27', lowNum: '27', uprightFor: 'horizontal' },
       ],
     },
   });

--- a/source/client/connectGroups.spec.ts
+++ b/source/client/connectGroups.spec.ts
@@ -9,8 +9,8 @@ test('can connect two simple groups vertically', () => {
     id: '81ff95',
     cards: {
       0: [
-        { id: '1', lowNum: '01', uprightFor: 'vertical' },
         { id: '2', lowNum: '02', uprightFor: 'vertical' },
+        { id: '1', lowNum: '01', uprightFor: 'vertical' },
       ],
     },
   };
@@ -18,8 +18,8 @@ test('can connect two simple groups vertically', () => {
     id: 'cf306b',
     cards: {
       0: [
-        { id: '3', lowNum: '03', uprightFor: 'vertical' },
         { id: '4', lowNum: '04', uprightFor: 'vertical' },
+        { id: '3', lowNum: '03', uprightFor: 'vertical' },
       ],
     },
   };
@@ -30,7 +30,7 @@ test('can connect two simple groups vertically', () => {
       connection: {
         card: { id: '2', lowNum: '02', uprightFor: 'vertical' },
         x: 0,
-        y: 1,
+        y: 0,
       },
     },
     group2: {
@@ -38,7 +38,7 @@ test('can connect two simple groups vertically', () => {
       connection: {
         card: { id: '3', lowNum: '03', uprightFor: 'vertical' },
         x: 0,
-        y: 0,
+        y: 1,
       },
     },
     orientation: 'vertical',
@@ -48,10 +48,10 @@ test('can connect two simple groups vertically', () => {
     id: '81ff95',
     cards: {
       0: [
-        { id: '1', lowNum: '01', uprightFor: 'vertical' },
-        { id: '2', lowNum: '02', uprightFor: 'vertical' },
-        { id: '3', lowNum: '03', uprightFor: 'vertical' },
         { id: '4', lowNum: '04', uprightFor: 'vertical' },
+        { id: '3', lowNum: '03', uprightFor: 'vertical' },
+        { id: '2', lowNum: '02', uprightFor: 'vertical' },
+        { id: '1', lowNum: '01', uprightFor: 'vertical' },
       ],
     },
   });
@@ -61,9 +61,9 @@ test('can vertically connect two groups of different width with negative offset'
     id: 'cf306b',
     cards: {
       0: [
-        null,
-        { id: '57', lowNum: '57', uprightFor: 'vertical' },
         { id: '58', lowNum: '58', uprightFor: 'vertical' },
+        { id: '57', lowNum: '57', uprightFor: 'vertical' },
+        null,
       ],
       1: [
         null,
@@ -75,27 +75,27 @@ test('can vertically connect two groups of different width with negative offset'
         null,
       ],
       2: [
-        {
-          id: '36',
-          lowNum: '36',
-          uprightFor: 'vertical',
-        },
+        null,
         {
           id: '37',
           lowNum: '37',
           uprightFor: 'vertical',
         },
-        null,
+        {
+          id: '36',
+          lowNum: '36',
+          uprightFor: 'vertical',
+        },
       ],
     },
   };
   const group2: Group = {
     id: '81ff95',
     cards: {
-      0: [{ id: '69', lowNum: '69', uprightFor: 'vertical' }, null],
+      0: [null, { id: '69', lowNum: '69', uprightFor: 'vertical' }],
       1: [
-        { id: '59', lowNum: '59', uprightFor: 'vertical' },
         { id: '60', lowNum: '60', uprightFor: 'vertical' },
+        { id: '59', lowNum: '59', uprightFor: 'vertical' },
       ],
     },
   };
@@ -106,7 +106,7 @@ test('can vertically connect two groups of different width with negative offset'
       connection: {
         card: { id: '58', lowNum: '58', uprightFor: 'vertical' },
         x: 0,
-        y: 2,
+        y: 0,
       },
     },
     group2: {
@@ -114,7 +114,7 @@ test('can vertically connect two groups of different width with negative offset'
       connection: {
         card: { id: '59', lowNum: '59', uprightFor: 'vertical' },
         x: 1,
-        y: 0,
+        y: 1,
       },
     },
     orientation: 'vertical',
@@ -125,19 +125,21 @@ test('can vertically connect two groups of different width with negative offset'
     cards: {
       0: [
         null,
-        null,
-        null,
         { id: '69', lowNum: '69', uprightFor: 'vertical' },
+        null,
+        null,
         null,
       ],
       1: [
-        null,
-        { id: '57', lowNum: '57', uprightFor: 'vertical' },
-        { id: '58', lowNum: '58', uprightFor: 'vertical' },
-        { id: '59', lowNum: '59', uprightFor: 'vertical' },
         { id: '60', lowNum: '60', uprightFor: 'vertical' },
+        { id: '59', lowNum: '59', uprightFor: 'vertical' },
+        { id: '58', lowNum: '58', uprightFor: 'vertical' },
+        { id: '57', lowNum: '57', uprightFor: 'vertical' },
+        null,
       ],
       2: [
+        null,
+        null,
         null,
         {
           id: '47',
@@ -145,23 +147,21 @@ test('can vertically connect two groups of different width with negative offset'
           uprightFor: 'vertical',
         },
         null,
-        null,
-        null,
       ],
       3: [
-        {
-          id: '36',
-          lowNum: '36',
-          uprightFor: 'vertical',
-        },
+        null,
+        null,
+        null,
         {
           id: '37',
           lowNum: '37',
           uprightFor: 'vertical',
         },
-        null,
-        null,
-        null,
+        {
+          id: '36',
+          lowNum: '36',
+          uprightFor: 'vertical',
+        },
       ],
     },
   });
@@ -172,14 +172,14 @@ test('can connect two groups vertically, with one extending past the beginning o
     id: 'cf306b',
     cards: {
       0: [
-        { id: '57', lowNum: '57', uprightFor: 'vertical' },
-        null,
         { id: '59', lowNum: '59', uprightFor: 'vertical' },
+        null,
+        { id: '57', lowNum: '57', uprightFor: 'vertical' },
       ],
       1: [
-        { id: '47', lowNum: '47', uprightFor: 'vertical' },
-        { id: '48', lowNum: '48', uprightFor: 'vertical' },
         { id: '49', lowNum: '49', uprightFor: 'vertical' },
+        { id: '48', lowNum: '48', uprightFor: 'vertical' },
+        { id: '47', lowNum: '47', uprightFor: 'vertical' },
       ],
     },
   };
@@ -188,11 +188,11 @@ test('can connect two groups vertically, with one extending past the beginning o
     id: '81ff95',
     cards: {
       0: [
-        { id: '66', lowNum: '66', uprightFor: 'vertical' },
-        { id: '67', lowNum: '67', uprightFor: 'vertical' },
         { id: '68', lowNum: '68', uprightFor: 'vertical' },
+        { id: '67', lowNum: '67', uprightFor: 'vertical' },
+        { id: '66', lowNum: '66', uprightFor: 'vertical' },
       ],
-      1: [null, null, { id: '58', lowNum: '58', uprightFor: 'vertical' }],
+      1: [{ id: '58', lowNum: '58', uprightFor: 'vertical' }, null, null],
     },
   };
 
@@ -200,17 +200,21 @@ test('can connect two groups vertically, with one extending past the beginning o
     group1: {
       group: group1,
       connection: {
-        card: group1.cards[0][0]!,
+        card: {
+          id: '57',
+          lowNum: '57',
+          uprightFor: 'vertical',
+        },
         x: 0,
-        y: 0,
+        y: 2,
       },
     },
     group2: {
       group: group2,
       connection: {
-        card: group2.cards[1][2]!,
+        card: { id: '58', lowNum: '58', uprightFor: 'vertical' },
         x: 1,
-        y: 2,
+        y: 0,
       },
     },
     orientation: 'vertical',
@@ -219,22 +223,22 @@ test('can connect two groups vertically, with one extending past the beginning o
     id: 'cf306b',
     cards: {
       0: [
-        { id: '66', lowNum: '66', uprightFor: 'vertical' },
-        { id: '67', lowNum: '67', uprightFor: 'vertical' },
-        { id: '68', lowNum: '68', uprightFor: 'vertical' },
         null,
+        { id: '68', lowNum: '68', uprightFor: 'vertical' },
+        { id: '67', lowNum: '67', uprightFor: 'vertical' },
+        { id: '66', lowNum: '66', uprightFor: 'vertical' },
       ],
       1: [
-        null,
-        { id: '57', lowNum: '57', uprightFor: 'vertical' },
-        { id: '58', lowNum: '58', uprightFor: 'vertical' },
         { id: '59', lowNum: '59', uprightFor: 'vertical' },
+        { id: '58', lowNum: '58', uprightFor: 'vertical' },
+        { id: '57', lowNum: '57', uprightFor: 'vertical' },
+        null,
       ],
       2: [
-        null,
-        { id: '47', lowNum: '47', uprightFor: 'vertical' },
-        { id: '48', lowNum: '48', uprightFor: 'vertical' },
         { id: '49', lowNum: '49', uprightFor: 'vertical' },
+        { id: '48', lowNum: '48', uprightFor: 'vertical' },
+        { id: '47', lowNum: '47', uprightFor: 'vertical' },
+        null,
       ],
     },
   };
@@ -244,17 +248,25 @@ test('can connect two groups vertically, with one extending past the beginning o
     group1: {
       group: group1,
       connection: {
-        card: group1.cards[0][2]!,
+        card: {
+          id: '59',
+          lowNum: '59',
+          uprightFor: 'vertical',
+        },
         x: 0,
-        y: 2,
+        y: 0,
       },
     },
     group2: {
       group: group2,
       connection: {
-        card: group2.cards[1][2]!,
+        card: {
+          id: '58',
+          lowNum: '58',
+          uprightFor: 'vertical',
+        },
         x: 1,
-        y: 2,
+        y: 0,
       },
     },
     orientation: 'vertical',

--- a/source/client/connectGroups.ts
+++ b/source/client/connectGroups.ts
@@ -26,15 +26,22 @@ function getGroupsByConnectionOrder({
       ? group2.connection.card.lowNum
       : group2.connection.card.lowNum.split('').toReversed().join('');
 
-  const group1IsGreater =
+  const group1ConnectionIsGreaterNum =
     parseInt(group1NumToCompare, 10) > parseInt(group2NumToCompare, 10);
 
-  // higherConnectingNumber = "right side" for horizontal, (left side in data)
-  // higher connectingNumber = "bottom" for vertical
-  return {
-    groupFrom: group1IsGreater ? group2 : group1,
-    groupTo: group1IsGreater ? group1 : group2,
-  };
+  // higher connecting number = "to the right" for horizontal, (left side in data)
+  // higher connecting number = "above" for vertical
+  if (orientation === 'horizontal') {
+    return {
+      groupFrom: group1ConnectionIsGreaterNum ? group2 : group1,
+      groupTo: group1ConnectionIsGreaterNum ? group1 : group2,
+    };
+  } else {
+    return {
+      groupFrom: group1ConnectionIsGreaterNum ? group1 : group2,
+      groupTo: group1ConnectionIsGreaterNum ? group2 : group1,
+    };
+  }
 }
 
 export function connectGroups({


### PR DESCRIPTION
## Overview

- In playtesting with Mark, he mentioned that the rulebook defines the order as high to low from top to bottom for the vertical player. I missed this.
- This PR addresses this.