### PR TITLE
Validate moves on the backend with server-authoritative replay (#26)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# Tether — Domain Glossary
+
+Canonical language for the Tether card game. Terms here are about the game
+domain, not the implementation.
+
+- **Card / Astronaut**: A double-sided card with two numbers that are digit
+  reversals of each other (e.g. 05/50). A card is identified by its **low
+  number** (the lesser of the two).
+- **Shown Number**: The number a card displays to a given player. A card
+  upright for a player's orientation shows its low number to them; otherwise
+  it shows the reversed digits.
+- **Orientation**: Which player a card is upright for: *vertical* (first
+  player) or *horizontal* (second player). Playing a card **flipped** makes it
+  upright for the opponent.
+- **Connection**: The pairing of a played card with a specific card already in
+  a group whose shown numbers differ by exactly 1. Any rules-valid connection
+  point is legal — not only the first one a UI happens to find.
+- **Group**: A set of connected cards laid out on a rectangular grid. The grid
+  is always described from the vertical player's perspective; the higher shown
+  number sits above (vertical) or to the right (horizontal) of its connection.
+- **Current Group**: The group started by the first card of the active
+  player's Connect Astronauts turn. Later cards this turn attach only to it.
+- **Starting a Group**: The first card played each turn always begins a new
+  group; pre-existing groups can only be extended by merging into them.
+- **Merge (Connect Groups)**: Joining the current group with another group at
+  a valid connection between one card of each. The merged group keeps the
+  higher of the two group identities. A turn may include any number of merges.
+- **Connect Astronauts**: The turn action of playing one or more cards
+  (from hand or the adrift zone, in any mix, at least one) and optionally
+  merging groups.
+- **Adrift Zone**: The shared face-up pool of cards. **Setting Adrift** is the
+  alternative turn action: discard a card from hand to the adrift zone, then
+  draw either from the deck or from the adrift zone — but never the card just
+  set adrift.
+- **Scoring Threshold**: A group triggers scoring when it reaches 6, 10, or 14
+  cards. The horizontal player scores the group's width, the vertical player
+  its height.

--- a/docs/adr/0001-server-authoritative-move-replay.md
+++ b/docs/adr/0001-server-authoritative-move-replay.md
@@ -1,0 +1,54 @@
+# ADR 0001: Server-authoritative move replay
+
+Date: 2026-07-05
+Status: Accepted
+
+## Context
+
+Move legality was originally computed only on the client (for velocity of
+implementation — see issue #26). `actConnectAstronauts` accepted the entire
+client-computed successor board state and wrote it to the database unchecked,
+so a crafted HTTP request could produce any board whatsoever.
+
+Three remedies were considered:
+
+1. **Validate the submitted successor state**: diff the DB state against the
+   client's state and check the diff is a legal move. Least client churn, but
+   "is this a legal successor?" is harder to get right than recomputing, and
+   subtle illegal states can slip through the diff logic.
+2. **Server recomputes from a minimal move description** (chosen): the client
+   sends an ordered move list (`startGroup` / `placeCard` / `mergeGroups`);
+   the server replays it with PHP ports of the client rule functions and
+   writes the state *it* computed. Illegal states become unrepresentable.
+3. **Hybrid**: send both and compare — belt-and-braces but permanent
+   duplication.
+
+## Decision
+
+The server is authoritative. `MoveValidator::replayConnectMoves` replays the
+submitted move list against DB state using `BoardLogic` (PHP ports of
+`getConnectingNumbers` / `getConnection` / `connectCardToGroup` /
+`connectGroups`), and any violation throws a `BgaUserException`, failing the
+action atomically. `actSetAdrift` is validated the same way.
+
+Each move names its **explicit connection** (card id + coordinates), and the
+server accepts **any rules-valid connection**, not just the one the current
+client UI auto-derives (first-match scan). This deliberately keeps the rules
+independent of a client implementation detail and permits a future UI where
+the player chooses among multiple valid connection spots
+(see docs/multiple-connection-spots-ui.md).
+
+## Consequences
+
+- The client's rule code remains, for optimistic local rendering only; the
+  shared JSON fixtures in `tests/fixtures/moves/` are run by both the uvu
+  specs (`source/client/fixtures.spec.ts`) and PHPUnit
+  (`tests/Unit/BoardLogicTest.php`) so the two implementations cannot drift
+  silently.
+- The PHP port is deliberately stricter in two spots the TS code mishandles
+  silently: placing onto an occupied cell and overlapping group merges are
+  rejected (fixture cases marked `phpOnly`).
+- Server and client may legitimately compute different layouts for the "same"
+  cards if a client ever submits a different valid connection than it renders
+  locally; the server's layout is the truth and the client re-syncs from
+  notifications/refresh.

--- a/docs/multiple-connection-spots-ui.md
+++ b/docs/multiple-connection-spots-ui.md
@@ -1,0 +1,43 @@
+# Design note: letting the player choose among multiple valid connection spots
+
+## Status
+
+Planned. The server-side groundwork already exists; this documents what the
+client needs when we build it.
+
+## Problem
+
+A played card can often legally connect to more than one card in the current
+group (its shown number ±1 may match several cards, and a merge may be
+possible at several pairs). Today the client auto-picks the *first* match its
+scan finds (`getConnection` in `source/client/getConnection.ts`), so the
+player never chooses — even though different connection points produce
+different layouts, and layout determines group width/height, which is exactly
+what scores.
+
+## What the server already supports
+
+Since ADR 0001, every submitted move carries an **explicit connection**
+(`connection: {cardId, x, y}`), and the server validates that the claimed
+connection is *any* rules-valid one — it does not insist on the first-match
+scan result. So a UI that lets the player pick among valid spots requires
+**no server changes**: it only needs to put the chosen connection into the
+move it already sends.
+
+## Client sketch
+
+1. When a card is selected to play, compute *all* valid connections instead
+   of the first: iterate the current group exactly like `getConnection` but
+   collect every match (a `getConnections` variant).
+2. If there is exactly one, behave as today.
+3. If there are several, highlight each candidate cell and ask the player to
+   click one; the click supplies the `connection` for the recorded
+   `placeCard` move (same flow for merge connection pairs).
+4. Local rendering keeps using `connectCardToGroup` with the chosen
+   connection, which already accepts an arbitrary connection argument.
+
+## Open questions
+
+- Should candidates that lead to identical layouts be collapsed?
+- Merge moves have two connection choices (one per group); the UI needs an
+  interaction for choosing the pair, or can enumerate valid pairs.

--- a/modules/php/BoardLogic.php
+++ b/modules/php/BoardLogic.php
@@ -1,0 +1,248 @@
+<?php
+declare(strict_types=1);
+
+namespace Bga\Games\TetherGame;
+
+/**
+ * Pure board-manipulation logic, ported from the client TypeScript
+ * (getConnectingNumbers.ts, getConnection.ts, connectCardToGroup.ts,
+ * connectGroups.ts) so the server can recompute board state itself.
+ *
+ * Data shapes match the client / GroupLogic::createGroupObjectForUI:
+ *   Card:  ['id' => string, 'lowNum' => string, 'uprightFor' => 'vertical'|'horizontal']
+ *   Group: ['id' => string, 'cards' => [x => [y => Card|null]]]
+ *   Connection: ['card' => Card, 'x' => int, 'y' => int]
+ *
+ * The grid is always stored from the vertical player's perspective.
+ *
+ * All violations throw \InvalidArgumentException; the framework layer
+ * (Game.php) converts them to user-visible errors.
+ */
+class BoardLogic
+{
+    /**
+     * Returns the two numbers (as zero-padded 2-char strings) that connect
+     * to the given shown number: exactly one lower and one higher.
+     */
+    public static function getConnectingNumbers(string $num): array
+    {
+        if (strlen($num) !== 2) {
+            throw new \InvalidArgumentException('the number string should be exactly 2 characters long');
+        }
+        $parsedNum = (int) $num;
+        if ($parsedNum < 1 || $parsedNum > 98) {
+            throw new \InvalidArgumentException('the number must be between 01 and 98');
+        }
+
+        $decremented = str_pad((string) ($parsedNum - 1), 2, '0', STR_PAD_LEFT);
+        $incremented = str_pad((string) ($parsedNum + 1), 2, '0', STR_PAD_LEFT);
+
+        return [$decremented, $incremented];
+    }
+
+    /**
+     * The number a card shows for the given orientation: its lowNum if the
+     * card is upright for that orientation, otherwise the digits reversed.
+     */
+    public static function shownNum(array $card, string $orientation): string
+    {
+        return $card['uprightFor'] === $orientation
+            ? $card['lowNum']
+            : strrev($card['lowNum']);
+    }
+
+    /**
+     * True when the two cards' shown numbers differ by exactly 1 for the
+     * given orientation, i.e. they may legally connect.
+     */
+    public static function isValidConnection(array $card, array $connectionCard, string $orientation): bool
+    {
+        $possibleNumbers = self::getConnectingNumbers(self::shownNum($card, $orientation));
+        return in_array(self::shownNum($connectionCard, $orientation), $possibleNumbers, true);
+    }
+
+    /**
+     * Finds a connection in the group for the given card (first match, same
+     * scan order as the client's getConnection). Throws if none exists.
+     */
+    public static function getConnection(array $card, array $group, string $orientation): array
+    {
+        $possibleNumbers = self::getConnectingNumbers(self::shownNum($card, $orientation));
+
+        foreach ($group['cards'] as $x => $column) {
+            foreach ($column as $y => $groupCard) {
+                if ($groupCard === null) {
+                    continue;
+                }
+                if (in_array(self::shownNum($groupCard, $orientation), $possibleNumbers, true)) {
+                    return ['card' => $groupCard, 'x' => (int) $x, 'y' => $y];
+                }
+            }
+        }
+        throw new \InvalidArgumentException('the card is not a valid option to connect to the group');
+    }
+
+    /**
+     * Places a card in the group adjacent to the connection point, mutating
+     * the group grid. The higher shown number goes above (vertical) or to the
+     * right (horizontal). Unlike the client, an occupied destination cell is
+     * rejected rather than silently mishandled.
+     */
+    public static function connectCardToGroup(array &$group, array $card, array $connection, string $orientation): void
+    {
+        $cardNumShown = (int) self::shownNum($card, $orientation);
+        $connectionCardNumShown = (int) self::shownNum($connection['card'], $orientation);
+
+        $numCols = count($group['cards']);
+        $x = $connection['x'];
+        $y = $connection['y'];
+
+        $connectionCell = $group['cards'][$x][$y] ?? null;
+        if ($connectionCell === null || (string) $connectionCell['id'] !== (string) $connection['card']['id']) {
+            throw new \InvalidArgumentException('The connecting card details are not correct');
+        }
+
+        // higher shown number goes after (above for vertical, right for horizontal)
+        $connectAfter = $connectionCardNumShown > $cardNumShown;
+
+        if ($orientation === 'vertical') {
+            $targetY = $connectAfter ? $y + 1 : $y - 1;
+            if (array_key_exists($targetY, $group['cards'][$x]) && $group['cards'][$x][$targetY] !== null) {
+                throw new \InvalidArgumentException('The destination cell is already occupied');
+            }
+            for ($i = 0; $i < $numCols; $i++) {
+                if (!isset($group['cards'][$i])) {
+                    throw new \InvalidArgumentException("something has gone wrong - cards for the column don't exist for some reason");
+                }
+                $itemToAdd = $i === $x ? $card : null;
+                if (array_key_exists($targetY, $group['cards'][$i])) {
+                    // an existing empty space we can fill
+                    if ($i === $x) {
+                        $group['cards'][$i][$targetY] = $itemToAdd;
+                    }
+                } elseif ($connectAfter) {
+                    $group['cards'][$i][] = $itemToAdd;
+                } else {
+                    array_unshift($group['cards'][$i], $itemToAdd);
+                }
+            }
+            return;
+        }
+
+        // horizontal: the data represents the vertical player's view, so
+        // left/right operate on the x (column) axis
+        $numRows = count($group['cards'][0]);
+        $targetX = $connectAfter ? $x + 1 : $x - 1;
+
+        if (isset($group['cards'][$targetX]) && array_key_exists($y, $group['cards'][$targetX])) {
+            if ($group['cards'][$targetX][$y] !== null) {
+                throw new \InvalidArgumentException('The destination cell is already occupied');
+            }
+            $group['cards'][$targetX][$y] = $card;
+            return;
+        }
+
+        $newColumn = [];
+        for ($i = 0; $i < $numRows; $i++) {
+            $newColumn[] = $i === $y ? $card : null;
+        }
+
+        if ($connectAfter) {
+            if ($x !== $numCols - 1) {
+                throw new \InvalidArgumentException('The destination cell is already occupied');
+            }
+            $group['cards'][$numCols] = $newColumn;
+            return;
+        }
+
+        if ($x !== 0) {
+            throw new \InvalidArgumentException('The destination cell is already occupied');
+        }
+        // adding at the start of the row: shift all columns to the right
+        for ($i = $numCols; $i >= 1; $i--) {
+            $group['cards'][$i] = $group['cards'][$i - 1];
+        }
+        $group['cards'][0] = $newColumn;
+    }
+
+    /**
+     * Merges two groups at the given connection points and returns the new
+     * group. The merged group takes the higher of the two group ids. Unlike
+     * the client, overlapping cells cause a rejection.
+     *
+     * $group1 / $group2: ['group' => Group, 'connection' => Connection]
+     */
+    public static function connectGroups(array $group1, array $group2, string $orientation): array
+    {
+        foreach ([$group1, $group2] as $g) {
+            $cell = $g['group']['cards'][$g['connection']['x']][$g['connection']['y']] ?? null;
+            if ($cell === null || (string) $cell['id'] !== (string) $g['connection']['card']['id']) {
+                throw new \InvalidArgumentException('The connecting card details are not correct');
+            }
+        }
+
+        // The FROM group is the one whose connection card shows the lesser number
+        $group1Num = (int) self::shownNum($group1['connection']['card'], $orientation);
+        $group2Num = (int) self::shownNum($group2['connection']['card'], $orientation);
+        $group1IsGreater = $group1Num > $group2Num;
+
+        // higher connecting number = "to the right" for horizontal (left side in data),
+        // higher connecting number = "above" for vertical
+        if ($orientation === 'horizontal') {
+            $groupFrom = $group1IsGreater ? $group2 : $group1;
+            $groupTo = $group1IsGreater ? $group1 : $group2;
+        } else {
+            $groupFrom = $group1IsGreater ? $group1 : $group2;
+            $groupTo = $group1IsGreater ? $group2 : $group1;
+        }
+
+        // Connect at relative positions 0,0 / 0,1 (vertical) or 0,0 / 1,0
+        // (horizontal, flipped in data), then normalize back to origin.
+        $relativeToY = $orientation === 'vertical' ? 1 : 0;
+        $relativeFromX = $orientation === 'horizontal' ? 1 : 0;
+
+        $temporaryCombined = [];
+        $rows = [];
+
+        $placements = [
+            [$groupFrom, $relativeFromX - $groupFrom['connection']['x'], 0 - $groupFrom['connection']['y']],
+            [$groupTo, 0 - $groupTo['connection']['x'], $relativeToY - $groupTo['connection']['y']],
+        ];
+
+        foreach ($placements as [$g, $xShift, $yShift]) {
+            foreach ($g['group']['cards'] as $x => $column) {
+                foreach ($column as $y => $card) {
+                    if ($card === null) {
+                        continue;
+                    }
+                    $offsetX = (int) $x + $xShift;
+                    $offsetY = $y + $yShift;
+                    if (isset($temporaryCombined[$offsetX][$offsetY])) {
+                        throw new \InvalidArgumentException('The groups overlap and cannot be connected there');
+                    }
+                    $temporaryCombined[$offsetX][$offsetY] = $card;
+                    $rows[$offsetY] = true;
+                }
+            }
+        }
+
+        $xOffset = min(0, ...array_map('intval', array_keys($temporaryCombined))) * -1;
+        $yOffset = min(0, ...array_keys($rows)) * -1;
+        $newGroupHeight = count($rows);
+
+        $newGroupId = max((int) $group1['group']['id'], (int) $group2['group']['id']);
+        $newGroup = ['id' => (string) $newGroupId, 'cards' => []];
+
+        foreach (array_keys($temporaryCombined) as $oldX) {
+            $newX = (int) $oldX + $xOffset;
+            $newGroup['cards'][$newX] = [];
+            for ($y = 0; $y < $newGroupHeight; $y++) {
+                $oldY = $y - $yOffset;
+                $newGroup['cards'][$newX][] = $temporaryCombined[$oldX][$oldY] ?? null;
+            }
+        }
+        ksort($newGroup['cards']);
+
+        return $newGroup;
+    }
+}

--- a/modules/php/Game.php
+++ b/modules/php/Game.php
@@ -134,25 +134,33 @@ class Game extends \Table
         $opponent_id = $this->getPlayerAfter($current_player_id);
 
         $hand = $this->cards->getCardsInLocation('hand', $current_player_id);
-        if (count($hand) < 6) {
-            $newCardFromDeck = $this->cards->pickCardForLocation('deck', 'hand', $current_player_id);
-            $newCardName = $this->formatCardName($newCardFromDeck['type_arg']);
-            $this->notify->player($current_player_id, 'drawFromDeck', clienttranslate('You drew the card ${card} from the deck at the end of your turn.'), [
-                'card' => $newCardName,
-                'card_id' => $newCardFromDeck['id'],
-                'card_num' => $newCardFromDeck['type_arg'],
-            ]);
-            $this->notify->player($opponent_id, 'drawOtherPlayer', clienttranslate('${player_name} drew a card from the deck to end their turn.'), [
-                'player_id' => $current_player_id,
-                'player_name' => $this->getPlayerNameById($current_player_id),
-            ]);
-        } else {
+        if (count($hand) >= 6) {
             $this->notify->player($current_player_id, 'dontDrawHandLimit', clienttranslate('You didn\'t draw a card at the end of your turn because you already had 6 cards in hand.'));
             $this->notify->player($opponent_id, 'dontDrawHandLimit', clienttranslate('${player_name} already has 6 cards in hand so they don\'t draw a card at the end of their turn.'), [
                 'player_id' => $current_player_id,
                 'player_name' => $this->getPlayerNameById($current_player_id),
             ]);
+            $this->gamestate->nextState('nextPlayer');
+            return;
         }
+
+        $newCardFromDeck = $this->cards->pickCardForLocation('deck', 'hand', $current_player_id);
+        if ($newCardFromDeck === null) {
+            $this->notify->all('dontDrawDeckEmpty', clienttranslate('The deck is empty, so no card is drawn at the end of the turn.'), []);
+            $this->gamestate->nextState('nextPlayer');
+            return;
+        }
+
+        $newCardName = $this->formatCardName($newCardFromDeck['type_arg']);
+        $this->notify->player($current_player_id, 'drawFromDeck', clienttranslate('You drew the card ${card} from the deck at the end of your turn.'), [
+            'card' => $newCardName,
+            'card_id' => $newCardFromDeck['id'],
+            'card_num' => $newCardFromDeck['type_arg'],
+        ]);
+        $this->notify->player($opponent_id, 'drawOtherPlayer', clienttranslate('${player_name} drew a card from the deck to end their turn.'), [
+            'player_id' => $current_player_id,
+            'player_name' => $this->getPlayerNameById($current_player_id),
+        ]);
         $this->gamestate->nextState('nextPlayer');
     }
 
@@ -333,6 +341,20 @@ class Game extends \Table
         $current_player_id = (int) $this->getCurrentPlayerId();
         $opponent_id = $this->getPlayerAfter($current_player_id);
 
+        // validate against the state BEFORE the action so the discarded card
+        // must come from the hand and cannot be drawn straight back
+        $hand = $this->cards->getCardsInLocation('hand', $current_player_id);
+        $adrift = $this->getCollectionFromDB(
+            "SELECT card_id id, card_type_arg lowNum
+            FROM card
+            WHERE card_location = 'adrift'"
+        );
+        try {
+            \Bga\Games\TetherGame\MoveValidator::validateSetAdrift($cardSetAdriftId, $cardDrawnId, $hand, $adrift);
+        } catch (\InvalidArgumentException $e) {
+            throw new \BgaUserException($e->getMessage());
+        }
+
         $this->cards->moveCard($cardSetAdriftId, 'adrift');
         $cardSetAdriftName = $this->formatCardName($cardSetAdriftNum);
         $this->notify->all('cardSetAdrift', clienttranslate('${player_name} sets ${card} adrift.'), [
@@ -413,81 +435,91 @@ class Game extends \Table
         return $groups;
     }
 
-    function actConnectAstronauts(#[JsonParam] array $gameStateJSON)
+    function actConnectAstronauts(#[JsonParam] array $moves)
     {
-        $initialAdriftState = $this->getCollectionFromDB(
-            "SELECT card_id id, card_type_arg cardNum
-            FROM card 
+        $current_player_id = (int) $this->getCurrentPlayerId();
+
+        // load the authoritative state from the database
+        $adrift = $this->getCollectionFromDB(
+            "SELECT card_id id, card_type_arg lowNum
+            FROM card
             WHERE card_location = 'adrift'"
         );
-        $current_player_id = (int) $this->getCurrentPlayerId();
-        $initialHandState = $this->cards->getCardsInLocation('hand', $current_player_id);
+        $handRows = $this->cards->getCardsInLocation('hand', $current_player_id);
+        $hand = array();
+        foreach ($handRows as $id => $handCard) {
+            $hand[$id] = ['id' => (string) $id, 'lowNum' => $handCard['type_arg']];
+        }
         $initialCardsInGroups = $this->getCollectionFromDB(
             "SELECT card_id id, card_type uprightFor, card_type_arg cardNum, card_location_arg groupAndCoords
             FROM card
             WHERE card_location = 'group'"
         );
         $initialCardsByGroup = $this->getCardsByGroup($initialCardsInGroups);
+        $board = \Bga\Games\TetherGame\GroupLogic::createGroupObjectForUI($initialCardsInGroups);
+        $latestGroup = count($board) > 0 ? (int) max(array_keys($board)) : 0;
 
-        $handDifferenceCards = array_diff_key($initialHandState, $gameStateJSON['hand']);
-        $adriftDifferenceCards = array_diff_key($initialAdriftState, $gameStateJSON['adrift']);
+        $playerNo = (int) $this->getUniqueValueFromDB(
+            "SELECT player_no FROM player WHERE player_id = $current_player_id"
+        );
+        $playerOrientation = $playerNo === 1 ? 'vertical' : 'horizontal';
 
-        $groupsPresent = array();
-
+        // replay the submitted moves server-side; the server - not the
+        // client - computes the resulting board and rejects illegal moves
         try {
-            // Use extracted helper to build card updates and execute single bulk query
-            $cardUpdates = \Bga\Games\TetherGame\CardUpdateHelper::buildCardUpdates($gameStateJSON['board']);
+            $result = \Bga\Games\TetherGame\MoveValidator::replayConnectMoves(
+                $moves,
+                $hand,
+                $adrift,
+                $board,
+                $playerOrientation,
+                $latestGroup
+            );
+        } catch (\InvalidArgumentException $e) {
+            throw new \BgaUserException($e->getMessage());
+        }
 
-            // Execute single bulk update instead of N queries (fixes N+1 problem)
-            if (!empty($cardUpdates)) {
-                $sql = \Bga\Games\TetherGame\CardUpdateHelper::generateBulkUpdateSQL($cardUpdates);
-                $this->DbQuery($sql);
-            }
+        $cardUpdates = \Bga\Games\TetherGame\CardUpdateHelper::buildCardUpdates($result['board']);
+        if (!empty($cardUpdates)) {
+            $sql = \Bga\Games\TetherGame\CardUpdateHelper::generateBulkUpdateSQL($cardUpdates);
+            $this->DbQuery($sql);
+        }
 
-            // Track which groups are present
-            $groupsPresent = array_flip(array_keys($gameStateJSON['board']));
+        // groups that no longer exist were merged into the played group
+        $groupNumsRemoved = array_diff_key($initialCardsByGroup, $result['board']);
+        $groupsAndCardsPlayed = array_intersect_key($initialCardsByGroup, $groupNumsRemoved);
 
-            // see the keys that were deleted
-            $groupNumsRemoved = array_diff_key($initialCardsByGroup, $groupsPresent);
-            // we need the cards by group
-            $groupsAndCardsPlayed = array_intersect_key($initialCardsByGroup, $groupNumsRemoved);
+        $opponent_id = $this->getPlayerAfter($current_player_id);
 
-            $opponent_id = $this->getPlayerAfter($current_player_id);
-
-            $this->bga->notify->player($opponent_id, 'connectFromHandOpponent', clienttranslate('${player_name} connected astronauts by playing the card(s) ${cards} from their hand.'), [
+        $this->bga->notify->player($opponent_id, 'connectFromHandOpponent', clienttranslate('${player_name} connected astronauts by playing the card(s) ${cards} from their hand.'), [
+            "player_id" => $current_player_id,
+            "player_name" => $this->getPlayerNameById($current_player_id),
+            "cards" => $this->formatCardsIntoCommaSeparatedString($result['playedFromHand'], 'lowNum'),
+        ]);
+        $this->bga->notify->player($current_player_id, 'connectFromHandSelf', clienttranslate('You connected astronauts by playing the card(s) ${cards} from your hand.'), [
+            "cards" => $this->formatCardsIntoCommaSeparatedString($result['playedFromHand'], 'lowNum')
+        ]);
+        if (count($result['playedFromAdrift']) > 0) {
+            $this->bga->notify->player($opponent_id, 'connectFromAdriftOpponent', clienttranslate('${player_name} connected the card(s) ${cards} from the adrift zone.'), [
                 "player_id" => $current_player_id,
                 "player_name" => $this->getPlayerNameById($current_player_id),
-                "cards" => $this->formatCardsIntoCommaSeparatedString($handDifferenceCards, 'type_arg'),
+                "cards" => $this->formatCardsIntoCommaSeparatedString($result['playedFromAdrift'], 'lowNum')
             ]);
-            $this->bga->notify->player($current_player_id, 'connectFromHandSelf', clienttranslate('You connected astronauts by playing the card(s) ${cards} from your hand.'), [
-                "cards" => $this->formatCardsIntoCommaSeparatedString($handDifferenceCards, 'type_arg')
+            $this->bga->notify->player($current_player_id, 'connectFromAdriftSelf', clienttranslate('You connected the card(s) ${cards} from the adrift zone.'), [
+                "cards" => $this->formatCardsIntoCommaSeparatedString($result['playedFromAdrift'], 'lowNum')
             ]);
-            if (count($adriftDifferenceCards) > 0) {
-                $this->bga->notify->player($opponent_id, 'connectFromAdriftOpponent', clienttranslate('${player_name} connected the card(s) ${cards} from the adrift zone.'), [
-                    "player_id" => $current_player_id,
-                    "player_name" => $this->getPlayerNameById($current_player_id),
-                    "cards" => $this->formatCardsIntoCommaSeparatedString($adriftDifferenceCards, 'cardNum')
-                ]);
-                $this->bga->notify->player($current_player_id, 'connectFromAdriftSelf', clienttranslate('You connected the card(s) ${cards} from the adrift zone.'), [
-                    "cards" => $this->formatCardsIntoCommaSeparatedString($adriftDifferenceCards, 'cardNum')
-                ]);
-            }
-            if (count($groupsAndCardsPlayed) > 0) {
-                $this->bga->notify->player($opponent_id, 'connectBoardOpponent', clienttranslate('${player_name} connected to the group(s) of cards: ${groups} from the board.'), [
-                    "player_id" => $current_player_id,
-                    "player_name" => $this->getPlayerNameById($current_player_id),
-                    "groups" => $this->getGroupsByCommaSeparatedCardStrings($groupsAndCardsPlayed)
-                ]);
-                $this->bga->notify->player($current_player_id, 'connectBoardSelf', clienttranslate('You connected to the group(s) of cards: ${groups} from the board.'), [
-                    "groups" => $this->getGroupsByCommaSeparatedCardStrings($groupsAndCardsPlayed)
-                ]);
-            }
-            $this->handleScoring();
-        } catch (\Exception $e) {
-            $this->error("Error while connecting astronauts");
-            $this->dump('err', $e);
-            return;
         }
+        if (count($groupsAndCardsPlayed) > 0) {
+            $this->bga->notify->player($opponent_id, 'connectBoardOpponent', clienttranslate('${player_name} connected to the group(s) of cards: ${groups} from the board.'), [
+                "player_id" => $current_player_id,
+                "player_name" => $this->getPlayerNameById($current_player_id),
+                "groups" => $this->getGroupsByCommaSeparatedCardStrings($groupsAndCardsPlayed)
+            ]);
+            $this->bga->notify->player($current_player_id, 'connectBoardSelf', clienttranslate('You connected to the group(s) of cards: ${groups} from the board.'), [
+                "groups" => $this->getGroupsByCommaSeparatedCardStrings($groupsAndCardsPlayed)
+            ]);
+        }
+        $this->handleScoring();
 
         $this->gamestate->nextState('drawAtEndOfTurn');
     }

--- a/modules/php/MoveValidator.php
+++ b/modules/php/MoveValidator.php
@@ -1,0 +1,195 @@
+<?php
+declare(strict_types=1);
+
+namespace Bga\Games\TetherGame;
+
+/**
+ * Validates and replays a player's turn server-side, so that the server —
+ * not the client — is the authority on move legality and resulting state
+ * (see docs/adr/0001-server-authoritative-move-replay.md).
+ *
+ * A "connect astronauts" turn is an ordered list of moves:
+ *   ['action' => 'startGroup',  'cardId' => string, 'from' => 'hand'|'adrift', 'flipped' => bool]
+ *   ['action' => 'placeCard',   'cardId' => string, 'from' => 'hand'|'adrift', 'flipped' => bool,
+ *    'connection' => ['cardId' => string, 'x' => int, 'y' => int]]
+ *   ['action' => 'mergeGroups', 'otherGroupId' => string,
+ *    'currentConnection' => ['cardId' => string, 'x' => int, 'y' => int],   // cell in current group
+ *    'otherConnection'   => ['cardId' => string, 'x' => int, 'y' => int]]  // cell in other group
+ *
+ * Enforced turn rules:
+ *   1. The first move always starts a NEW group; existing groups are only
+ *      extended via merges.
+ *   2. Later cards attach only to the current turn's group.
+ *   3. At least one card must be played; any mix of hand/adrift, no limit.
+ *   4. Any number of merges, each requiring a valid +-1 connection.
+ *
+ * A claimed connection is accepted if it is ANY rules-valid connection, not
+ * necessarily the one the current client UI would auto-pick.
+ *
+ * Pure static class - throws \InvalidArgumentException on any violation.
+ */
+class MoveValidator
+{
+    /**
+     * Replays the moves against the current server-side state and returns
+     * the resulting board plus what was consumed, or throws.
+     *
+     * @param array $moves ordered move list (see class doc)
+     * @param array $hand card id => ['id','lowNum'] cards in the player's hand
+     * @param array $adrift card id => ['id','lowNum'] cards in the adrift zone
+     * @param array $board group id => Group (GroupLogic::createGroupObjectForUI shape)
+     * @param string $playerOrientation 'vertical'|'horizontal'
+     * @param int $latestGroup highest group id currently on the board
+     * @return array ['board' => groups, 'playedFromHand' => Card[], 'playedFromAdrift' => Card[]]
+     */
+    public static function replayConnectMoves(
+        array $moves,
+        array $hand,
+        array $adrift,
+        array $board,
+        string $playerOrientation,
+        int $latestGroup
+    ): array {
+        if (count($moves) === 0) {
+            throw new \InvalidArgumentException('At least one card must be played');
+        }
+
+        $sources = ['hand' => $hand, 'adrift' => $adrift];
+        $played = ['hand' => [], 'adrift' => []];
+        $currentGroupId = null;
+
+        foreach ($moves as $i => $move) {
+            $action = $move['action'] ?? null;
+
+            if ($i === 0 && $action !== 'startGroup') {
+                throw new \InvalidArgumentException('The first card played must start a new group');
+            }
+            if ($i !== 0 && $action === 'startGroup') {
+                throw new \InvalidArgumentException('Only the first card played may start a new group');
+            }
+
+            switch ($action) {
+                case 'startGroup':
+                    $card = self::takeCard($move, $sources, $played, $playerOrientation);
+                    $currentGroupId = (string) ($latestGroup + 1);
+                    $board[$currentGroupId] = [
+                        'id' => $currentGroupId,
+                        'cards' => [0 => [0 => $card]],
+                    ];
+                    break;
+
+                case 'placeCard':
+                    $card = self::takeCard($move, $sources, $played, $playerOrientation);
+                    $group = &$board[$currentGroupId];
+                    $connection = self::resolveConnection($move['connection'] ?? null, $group);
+                    if (!BoardLogic::isValidConnection($card, $connection['card'], $playerOrientation)) {
+                        throw new \InvalidArgumentException('The card does not connect to the chosen card');
+                    }
+                    BoardLogic::connectCardToGroup($group, $card, $connection, $playerOrientation);
+                    unset($group);
+                    break;
+
+                case 'mergeGroups':
+                    $otherGroupId = (string) ($move['otherGroupId'] ?? '');
+                    if (!isset($board[$otherGroupId])) {
+                        throw new \InvalidArgumentException('The group to connect to does not exist');
+                    }
+                    if ($otherGroupId === $currentGroupId) {
+                        throw new \InvalidArgumentException('A group cannot be connected to itself');
+                    }
+                    $currentConnection = self::resolveConnection($move['currentConnection'] ?? null, $board[$currentGroupId]);
+                    $otherConnection = self::resolveConnection($move['otherConnection'] ?? null, $board[$otherGroupId]);
+                    if (!BoardLogic::isValidConnection($currentConnection['card'], $otherConnection['card'], $playerOrientation)) {
+                        throw new \InvalidArgumentException('The two groups do not connect at the chosen cards');
+                    }
+                    $merged = BoardLogic::connectGroups(
+                        ['group' => $board[$currentGroupId], 'connection' => $currentConnection],
+                        ['group' => $board[$otherGroupId], 'connection' => $otherConnection],
+                        $playerOrientation
+                    );
+                    unset($board[$currentGroupId], $board[$otherGroupId]);
+                    $currentGroupId = $merged['id'];
+                    $board[$currentGroupId] = $merged;
+                    break;
+
+                default:
+                    throw new \InvalidArgumentException('Unknown move action');
+            }
+        }
+
+        return [
+            'board' => $board,
+            'playedFromHand' => $played['hand'],
+            'playedFromAdrift' => $played['adrift'],
+        ];
+    }
+
+    /**
+     * Validates an actSetAdrift request against the state BEFORE the action:
+     * the discarded card must be in the player's hand, and the drawn card
+     * must be the deck or a card already in the adrift zone (you cannot take
+     * back the card you just set adrift).
+     */
+    public static function validateSetAdrift(
+        string $cardSetAdriftId,
+        string $cardDrawnId,
+        array $hand,
+        array $adrift
+    ): void {
+        if (!isset($hand[$cardSetAdriftId])) {
+            throw new \InvalidArgumentException('The card to set adrift is not in your hand');
+        }
+        if ($cardDrawnId === 'deck') {
+            return;
+        }
+        if ($cardDrawnId === $cardSetAdriftId) {
+            throw new \InvalidArgumentException('You cannot take back the card you just set adrift');
+        }
+        if (!isset($adrift[$cardDrawnId])) {
+            throw new \InvalidArgumentException('The card to draw is not in the adrift zone');
+        }
+    }
+
+    /**
+     * Consumes the played card from its claimed source zone and returns it
+     * as a board Card with its orientation derived from the flipped flag.
+     */
+    private static function takeCard(array $move, array &$sources, array &$played, string $playerOrientation): array
+    {
+        $from = $move['from'] ?? null;
+        if ($from !== 'hand' && $from !== 'adrift') {
+            throw new \InvalidArgumentException('Cards can only be played from your hand or the adrift zone');
+        }
+        $cardId = (string) ($move['cardId'] ?? '');
+        if (!isset($sources[$from][$cardId])) {
+            throw new \InvalidArgumentException("The card is not available to play from the $from");
+        }
+        $sourceCard = $sources[$from][$cardId];
+        unset($sources[$from][$cardId]);
+
+        $otherOrientation = $playerOrientation === 'vertical' ? 'horizontal' : 'vertical';
+        $card = [
+            'id' => $cardId,
+            'lowNum' => $sourceCard['lowNum'],
+            'uprightFor' => !empty($move['flipped']) ? $otherOrientation : $playerOrientation,
+        ];
+        $played[$from][] = $card;
+
+        return $card;
+    }
+
+    /**
+     * Checks the claimed connection cell exists in the group and holds the
+     * claimed card, returning a full Connection.
+     */
+    private static function resolveConnection(?array $claimed, array $group): array
+    {
+        $x = isset($claimed['x']) ? (int) $claimed['x'] : -1;
+        $y = isset($claimed['y']) ? (int) $claimed['y'] : -1;
+        $cell = $group['cards'][$x][$y] ?? null;
+        if ($cell === null || !isset($claimed['cardId']) || (string) $cell['id'] !== (string) $claimed['cardId']) {
+            throw new \InvalidArgumentException('The connecting card details are not correct');
+        }
+        return ['card' => $cell, 'x' => $x, 'y' => $y];
+    }
+}

--- a/source/client/build/gamestates.d.ts
+++ b/source/client/build/gamestates.d.ts
@@ -66,7 +66,7 @@ interface GameStateArgs {}
 
 interface GameStatePossibleActions {
 	'actConnectAstronauts': {
-		'gameStateJSON': string,
+		'moves': string,
 	},
 	'actSetAdrift': {
 		'cardDrawnId': string,

--- a/source/client/fixtures.spec.ts
+++ b/source/client/fixtures.spec.ts
@@ -1,0 +1,123 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  connectCardToGroup,
+  Card,
+  Group,
+  Orientation,
+} from './connectCardToGroup';
+import { connectGroups } from './connectGroups';
+import { getConnection } from './getConnection';
+import { getConnectingNumbers } from './getConnectingNumbers';
+
+// These JSON fixtures are shared with the server: the same scenarios are run
+// against the PHP ports in tests/Unit/BoardLogicTest.php, so the two rule
+// implementations cannot drift apart silently. Cases marked phpOnly cover
+// server-side hardening that the client does not implement.
+
+const fixturesDir = path.join(__dirname, '..', '..', 'tests', 'fixtures', 'moves');
+
+function loadFixtures<T>(file: string): T[] {
+  return JSON.parse(fs.readFileSync(path.join(fixturesDir, file), 'utf8'));
+}
+
+interface BaseCase {
+  name: string;
+  phpOnly?: boolean;
+  error?: string;
+}
+
+interface GroupWithConnection {
+  group: Group;
+  connection: { card: Card; x: number; y: number };
+}
+
+function throwsWithMessage(fn: () => unknown, message: string) {
+  assert.throws(fn, (err: Error) => err.message === message);
+}
+
+for (const c of loadFixtures<BaseCase & { num: string; expected?: string[] }>(
+  'getConnectingNumbers.json'
+)) {
+  if (c.phpOnly) continue;
+  test(`fixture: getConnectingNumbers - ${c.name}`, () => {
+    if (c.error !== undefined) {
+      throwsWithMessage(() => getConnectingNumbers(c.num), c.error);
+    } else {
+      assert.equal(getConnectingNumbers(c.num), c.expected);
+    }
+  });
+}
+
+for (const c of loadFixtures<
+  BaseCase & {
+    card: Card;
+    group: Group;
+    orientation: Orientation;
+    expected?: { card: Card; x: number; y: number };
+  }
+>('getConnection.json')) {
+  if (c.phpOnly) continue;
+  test(`fixture: getConnection - ${c.name}`, () => {
+    if (c.error !== undefined) {
+      throwsWithMessage(() => getConnection(c.card, c.group, c.orientation), c.error);
+    } else {
+      assert.equal(getConnection(c.card, c.group, c.orientation), c.expected);
+    }
+  });
+}
+
+for (const c of loadFixtures<
+  BaseCase & {
+    group: Group;
+    card: Card;
+    connection: { card: Card; x: number; y: number };
+    orientation: Orientation;
+    expected?: Group;
+  }
+>('connectCardToGroup.json')) {
+  if (c.phpOnly) continue;
+  test(`fixture: connectCardToGroup - ${c.name}`, () => {
+    const run = () =>
+      connectCardToGroup({
+        group: c.group,
+        card: c.card,
+        connection: c.connection,
+        orientation: c.orientation,
+      });
+    if (c.error !== undefined) {
+      throwsWithMessage(run, c.error);
+    } else {
+      run();
+      assert.equal(c.group, c.expected);
+    }
+  });
+}
+
+for (const c of loadFixtures<
+  BaseCase & {
+    group1: GroupWithConnection;
+    group2: GroupWithConnection;
+    orientation: Orientation;
+    expected?: Group;
+  }
+>('connectGroups.json')) {
+  if (c.phpOnly) continue;
+  test(`fixture: connectGroups - ${c.name}`, () => {
+    const run = () =>
+      connectGroups({
+        group1: c.group1,
+        group2: c.group2,
+        orientation: c.orientation,
+      });
+    if (c.error !== undefined) {
+      throwsWithMessage(run, c.error);
+    } else {
+      assert.equal(run(), c.expected);
+    }
+  });
+}
+
+test.run();

--- a/source/client/tethergame.ts
+++ b/source/client/tethergame.ts
@@ -64,6 +64,38 @@ type ClientState =
       };
     };
 
+interface MoveConnection {
+  cardId: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * The minimal description of one step of a Connect Astronauts turn. The
+ * ordered list of these is what gets sent to the server, which replays and
+ * validates them rather than trusting a client-computed board state.
+ */
+type ConnectMove =
+  | {
+      action: 'startGroup';
+      cardId: string;
+      from: 'hand' | 'adrift';
+      flipped: boolean;
+    }
+  | {
+      action: 'placeCard';
+      cardId: string;
+      from: 'hand' | 'adrift';
+      flipped: boolean;
+      connection: MoveConnection;
+    }
+  | {
+      action: 'mergeGroups';
+      otherGroupId: string;
+      currentConnection: MoveConnection;
+      otherConnection: MoveConnection;
+    };
+
 /** See {@link BGA.Gamegui} for more information. */
 class TetherGame extends Gamegui {
   eventHandlers: {
@@ -98,10 +130,13 @@ class TetherGame extends Gamegui {
 
   playableCardNumbers: string[] = [];
 
+  /** The moves made so far this turn, sent to the server on submit. */
+  turnMoves: ConnectMove[] = [];
+
   /** See {@link BGA.Gamegui} for more information. */
   constructor() {
     super();
-    console.log('tethergame constructor');
+    console.log('tethergame constructor is working');
   }
 
   createCardElement({
@@ -755,6 +790,7 @@ class TetherGame extends Gamegui {
 
   // #region Connect Astronauts Action methods
   cancelConnectAstronautsAction() {
+    this.turnMoves = [];
     this.clearSelectedCards();
     this.clearSelectableCards();
     this.clearEventListeners();
@@ -800,6 +836,7 @@ class TetherGame extends Gamegui {
     });
 
     if (this.clientState.status === 'choosingAction') {
+      this.turnMoves = [];
       this.clientState = { status: 'connectingAstronautsInitial' };
       this.setClientState('client_connectAstronautInitial', {
         // @ts-expect-error
@@ -956,6 +993,21 @@ class TetherGame extends Gamegui {
       orientation: this.playerDirection!,
     });
 
+    this.turnMoves.push({
+      action: 'mergeGroups',
+      otherGroupId: groupToConnectId,
+      currentConnection: {
+        cardId: currentGroupConnectionPoint.card.id,
+        x: currentGroupConnectionPoint.x,
+        y: currentGroupConnectionPoint.y,
+      },
+      otherConnection: {
+        cardId: cardToConnect.id,
+        x: parseInt(x, 10),
+        y: parseInt(y, 10),
+      },
+    });
+
     // the current group always has a higher ID, so we delete the lower one
     delete this.gameStateCurrent.board[groupToConnectId];
     this.gameStateCurrent.board[combinedGroup.id] = combinedGroup;
@@ -1033,6 +1085,7 @@ class TetherGame extends Gamegui {
         card,
         newGroupId
       );
+      this.turnMoves.push({ action: 'startGroup', cardId: id, from, flipped });
       this.updateBoardUI();
     } else {
       // connect card to that group
@@ -1055,11 +1108,27 @@ class TetherGame extends Gamegui {
         uprightFor,
       };
 
+      const connection = getConnection(
+        cardToConnect,
+        group,
+        this.playerDirection
+      );
       connectCardToGroup({
         group,
         card: cardToConnect,
-        connection: getConnection(cardToConnect, group, this.playerDirection),
+        connection,
         orientation: this.playerDirection,
+      });
+      this.turnMoves.push({
+        action: 'placeCard',
+        cardId: id,
+        from,
+        flipped,
+        connection: {
+          cardId: connection.card.id,
+          x: connection.x,
+          y: connection.y,
+        },
       });
       this.updateBoardUI();
     }
@@ -1070,8 +1139,9 @@ class TetherGame extends Gamegui {
 
   finishConnectingAstronauts() {
     this.bgaPerformAction('actConnectAstronauts', {
-      gameStateJSON: JSON.stringify(this.gameStateCurrent),
+      moves: JSON.stringify(this.turnMoves),
     });
+    this.turnMoves = [];
     this.clearSelectableCards();
   }
   // #endregion

--- a/source/shared/gamestates.jsonc
+++ b/source/shared/gamestates.jsonc
@@ -35,7 +35,7 @@
     "possibleactions": {
       "actConnectAstronauts": [
         {
-          "name": "gameStateJSON",
+          "name": "moves",
           "type": "AT_json"
         }
       ],

--- a/tests/Unit/BoardLogicTest.php
+++ b/tests/Unit/BoardLogicTest.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace Bga\Games\TetherGame\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Bga\Games\TetherGame\BoardLogic;
+
+/**
+ * Fixture-driven tests shared with the client: the same JSON scenarios in
+ * tests/fixtures/moves are run against the TypeScript implementations by
+ * source/client/fixtures.spec.ts, so the two rule implementations cannot
+ * drift apart silently. Cases marked "phpOnly" cover server hardening the
+ * client does not implement.
+ */
+class BoardLogicTest extends TestCase
+{
+    private static function loadFixtures(string $file): array
+    {
+        $json = file_get_contents(__DIR__ . '/../fixtures/moves/' . $file);
+        return json_decode($json, true);
+    }
+
+    /**
+     * Group cards decoded from JSON need their column keys as ints, matching
+     * the shape GroupLogic::createGroupObjectForUI produces.
+     */
+    private static function normalizeGroup(array $group): array
+    {
+        $cards = [];
+        foreach ($group['cards'] as $x => $column) {
+            $cards[(int) $x] = $column;
+        }
+        $group['cards'] = $cards;
+        return $group;
+    }
+
+    public function testGetConnectingNumbersFixtures(): void
+    {
+        foreach (self::loadFixtures('getConnectingNumbers.json') as $case) {
+            if (isset($case['error'])) {
+                try {
+                    BoardLogic::getConnectingNumbers($case['num']);
+                    $this->fail("Expected exception for case: {$case['name']}");
+                } catch (\InvalidArgumentException $e) {
+                    $this->assertSame($case['error'], $e->getMessage(), $case['name']);
+                }
+            } else {
+                $this->assertSame($case['expected'], BoardLogic::getConnectingNumbers($case['num']), $case['name']);
+            }
+        }
+    }
+
+    public function testGetConnectionFixtures(): void
+    {
+        foreach (self::loadFixtures('getConnection.json') as $case) {
+            $group = self::normalizeGroup($case['group']);
+            if (isset($case['error'])) {
+                try {
+                    BoardLogic::getConnection($case['card'], $group, $case['orientation']);
+                    $this->fail("Expected exception for case: {$case['name']}");
+                } catch (\InvalidArgumentException $e) {
+                    $this->assertSame($case['error'], $e->getMessage(), $case['name']);
+                }
+            } else {
+                $this->assertEquals(
+                    $case['expected'],
+                    BoardLogic::getConnection($case['card'], $group, $case['orientation']),
+                    $case['name']
+                );
+            }
+        }
+    }
+
+    public function testConnectCardToGroupFixtures(): void
+    {
+        foreach (self::loadFixtures('connectCardToGroup.json') as $case) {
+            $group = self::normalizeGroup($case['group']);
+            $connection = [
+                'card' => $case['connection']['card'],
+                'x' => $case['connection']['x'],
+                'y' => $case['connection']['y'],
+            ];
+            if (isset($case['error'])) {
+                try {
+                    BoardLogic::connectCardToGroup($group, $case['card'], $connection, $case['orientation']);
+                    $this->fail("Expected exception for case: {$case['name']}");
+                } catch (\InvalidArgumentException $e) {
+                    $this->assertSame($case['error'], $e->getMessage(), $case['name']);
+                }
+            } else {
+                BoardLogic::connectCardToGroup($group, $case['card'], $connection, $case['orientation']);
+                $this->assertEquals(self::normalizeGroup($case['expected']), $group, $case['name']);
+            }
+        }
+    }
+
+    public function testConnectGroupsFixtures(): void
+    {
+        foreach (self::loadFixtures('connectGroups.json') as $case) {
+            $group1 = [
+                'group' => self::normalizeGroup($case['group1']['group']),
+                'connection' => $case['group1']['connection'],
+            ];
+            $group2 = [
+                'group' => self::normalizeGroup($case['group2']['group']),
+                'connection' => $case['group2']['connection'],
+            ];
+            if (isset($case['error'])) {
+                try {
+                    BoardLogic::connectGroups($group1, $group2, $case['orientation']);
+                    $this->fail("Expected exception for case: {$case['name']}");
+                } catch (\InvalidArgumentException $e) {
+                    $this->assertSame($case['error'], $e->getMessage(), $case['name']);
+                }
+            } else {
+                $this->assertEquals(
+                    self::normalizeGroup($case['expected']),
+                    BoardLogic::connectGroups($group1, $group2, $case['orientation']),
+                    $case['name']
+                );
+            }
+        }
+    }
+}

--- a/tests/Unit/GroupLogicTest.php
+++ b/tests/Unit/GroupLogicTest.php
@@ -62,7 +62,7 @@ class GroupLogicTest extends TestCase
         $group1 = $result['1'];
         $group2 = $result['2'];
 
-        $this->assertEquals('1', $group1['number']); // group number
+        $this->assertEquals('1', $group1['id']); // group number
         $this->assertIsArray($group1['cards']);
         $this->assertEquals('2', $group1['cards'][0][0]['id']);
         $this->assertEquals('02', $group1['cards'][0][0]['lowNum']);

--- a/tests/Unit/MoveValidatorTest.php
+++ b/tests/Unit/MoveValidatorTest.php
@@ -1,0 +1,318 @@
+<?php
+declare(strict_types=1);
+
+namespace Bga\Games\TetherGame\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Bga\Games\TetherGame\MoveValidator;
+
+class MoveValidatorTest extends TestCase
+{
+    private const HAND = [
+        '11' => ['id' => '11', 'lowNum' => '05'],
+        '12' => ['id' => '12', 'lowNum' => '06'],
+    ];
+    private const ADRIFT = [
+        '21' => ['id' => '21', 'lowNum' => '07'],
+    ];
+    private const BOARD = [
+        '1' => [
+            'id' => '1',
+            'cards' => [
+                0 => [
+                    0 => ['id' => '31', 'lowNum' => '04', 'uprightFor' => 'vertical'],
+                    1 => ['id' => '32', 'lowNum' => '03', 'uprightFor' => 'vertical'],
+                ],
+            ],
+        ],
+    ];
+
+    public function testHappyPathStartGroupThenPlaceCardsFromHandAndAdrift(): void
+    {
+        $result = MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'placeCard',
+                    'cardId' => '12',
+                    'from' => 'hand',
+                    'flipped' => false,
+                    'connection' => ['cardId' => '11', 'x' => 0, 'y' => 0],
+                ],
+                [
+                    'action' => 'placeCard',
+                    'cardId' => '21',
+                    'from' => 'adrift',
+                    'flipped' => false,
+                    'connection' => ['cardId' => '12', 'x' => 0, 'y' => 0],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+
+        $this->assertCount(2, $result['playedFromHand']);
+        $this->assertCount(1, $result['playedFromAdrift']);
+        // new group 2 built as a single column, highest number on top
+        $this->assertEquals(
+            [
+                0 => [
+                    0 => ['id' => '21', 'lowNum' => '07', 'uprightFor' => 'vertical'],
+                    1 => ['id' => '12', 'lowNum' => '06', 'uprightFor' => 'vertical'],
+                    2 => ['id' => '11', 'lowNum' => '05', 'uprightFor' => 'vertical'],
+                ],
+            ],
+            $result['board']['2']['cards']
+        );
+        // pre-existing group untouched
+        $this->assertArrayHasKey('1', $result['board']);
+    }
+
+    public function testMergeGroupsCombinesCurrentGroupWithExistingGroup(): void
+    {
+        $result = MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'mergeGroups',
+                    'otherGroupId' => '1',
+                    'currentConnection' => ['cardId' => '11', 'x' => 0, 'y' => 0],
+                    'otherConnection' => ['cardId' => '31', 'x' => 0, 'y' => 0],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+
+        // groups 1 and 2 merged into group 2 (max id), column 05-04-03
+        $this->assertArrayNotHasKey('1', $result['board']);
+        $this->assertEquals(
+            [
+                0 => [
+                    0 => ['id' => '11', 'lowNum' => '05', 'uprightFor' => 'vertical'],
+                    1 => ['id' => '31', 'lowNum' => '04', 'uprightFor' => 'vertical'],
+                    2 => ['id' => '32', 'lowNum' => '03', 'uprightFor' => 'vertical'],
+                ],
+            ],
+            $result['board']['2']['cards']
+        );
+    }
+
+    public function testFlippedCardUsesOppositeOrientation(): void
+    {
+        $result = MoveValidator::replayConnectMoves(
+            [['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => true]],
+            self::HAND,
+            self::ADRIFT,
+            [],
+            'vertical',
+            0
+        );
+
+        $this->assertSame('horizontal', $result['board']['1']['cards'][0][0]['uprightFor']);
+    }
+
+    public function testRejectsEmptyMoveList(): void
+    {
+        $this->expectExceptionMessage('At least one card must be played');
+        MoveValidator::replayConnectMoves([], self::HAND, self::ADRIFT, self::BOARD, 'vertical', 1);
+    }
+
+    public function testRejectsFirstMoveThatIsNotStartGroup(): void
+    {
+        $this->expectExceptionMessage('The first card played must start a new group');
+        MoveValidator::replayConnectMoves(
+            [[
+                'action' => 'placeCard',
+                'cardId' => '11',
+                'from' => 'hand',
+                'flipped' => false,
+                'connection' => ['cardId' => '31', 'x' => 0, 'y' => 0],
+            ]],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsSecondStartGroup(): void
+    {
+        $this->expectExceptionMessage('Only the first card played may start a new group');
+        MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                ['action' => 'startGroup', 'cardId' => '12', 'from' => 'hand', 'flipped' => false],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsCardNotInHand(): void
+    {
+        $this->expectExceptionMessage('The card is not available to play from the hand');
+        MoveValidator::replayConnectMoves(
+            [['action' => 'startGroup', 'cardId' => '99', 'from' => 'hand', 'flipped' => false]],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsPlayingTheSameCardTwice(): void
+    {
+        $this->expectExceptionMessage('The card is not available to play from the hand');
+        MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'placeCard',
+                    'cardId' => '11',
+                    'from' => 'hand',
+                    'flipped' => false,
+                    'connection' => ['cardId' => '11', 'x' => 0, 'y' => 0],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsNonAdjacentConnection(): void
+    {
+        // card 07 does not connect to card 05 (difference of 2)
+        $this->expectExceptionMessage('The card does not connect to the chosen card');
+        MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'placeCard',
+                    'cardId' => '21',
+                    'from' => 'adrift',
+                    'flipped' => false,
+                    'connection' => ['cardId' => '11', 'x' => 0, 'y' => 0],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsConnectionClaimForWrongCell(): void
+    {
+        $this->expectExceptionMessage('The connecting card details are not correct');
+        MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'placeCard',
+                    'cardId' => '12',
+                    'from' => 'hand',
+                    'flipped' => false,
+                    'connection' => ['cardId' => '11', 'x' => 3, 'y' => 3],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsMergeWithNonexistentGroup(): void
+    {
+        $this->expectExceptionMessage('The group to connect to does not exist');
+        MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '11', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'mergeGroups',
+                    'otherGroupId' => '9',
+                    'currentConnection' => ['cardId' => '11', 'x' => 0, 'y' => 0],
+                    'otherConnection' => ['cardId' => '31', 'x' => 0, 'y' => 0],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    public function testRejectsMergeWhereGroupsDoNotConnect(): void
+    {
+        // current group card 06 vs other group card 03: difference of 3
+        $this->expectExceptionMessage('The two groups do not connect at the chosen cards');
+        MoveValidator::replayConnectMoves(
+            [
+                ['action' => 'startGroup', 'cardId' => '12', 'from' => 'hand', 'flipped' => false],
+                [
+                    'action' => 'mergeGroups',
+                    'otherGroupId' => '1',
+                    'currentConnection' => ['cardId' => '12', 'x' => 0, 'y' => 0],
+                    'otherConnection' => ['cardId' => '32', 'x' => 0, 'y' => 1],
+                ],
+            ],
+            self::HAND,
+            self::ADRIFT,
+            self::BOARD,
+            'vertical',
+            1
+        );
+    }
+
+    // #region validateSetAdrift
+
+    public function testSetAdriftAllowsHandCardAndDeckDraw(): void
+    {
+        MoveValidator::validateSetAdrift('11', 'deck', self::HAND, self::ADRIFT);
+        $this->assertTrue(true);
+    }
+
+    public function testSetAdriftAllowsDrawingFromAdriftZone(): void
+    {
+        MoveValidator::validateSetAdrift('11', '21', self::HAND, self::ADRIFT);
+        $this->assertTrue(true);
+    }
+
+    public function testSetAdriftRejectsCardNotInHand(): void
+    {
+        $this->expectExceptionMessage('The card to set adrift is not in your hand');
+        MoveValidator::validateSetAdrift('99', 'deck', self::HAND, self::ADRIFT);
+    }
+
+    public function testSetAdriftRejectsTakingBackTheSameCard(): void
+    {
+        $this->expectExceptionMessage('You cannot take back the card you just set adrift');
+        MoveValidator::validateSetAdrift('11', '11', self::HAND, self::ADRIFT);
+    }
+
+    public function testSetAdriftRejectsDrawingCardNotInAdriftZone(): void
+    {
+        $this->expectExceptionMessage('The card to draw is not in the adrift zone');
+        MoveValidator::validateSetAdrift('11', '12', self::HAND, self::ADRIFT);
+    }
+
+    // #endregion
+}

--- a/tests/fixtures/moves/connectCardToGroup.json
+++ b/tests/fixtures/moves/connectCardToGroup.json
@@ -1,0 +1,267 @@
+[
+  {
+    "name": "extends columns when connecting vertically at the end",
+    "orientation": "vertical",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "2", "lowNum": "02", "uprightFor": "vertical" },
+          { "id": "1", "lowNum": "01", "uprightFor": "vertical" }
+        ],
+        "1": [{ "id": "19", "lowNum": "19", "uprightFor": "horizontal" }, null]
+      }
+    },
+    "card": { "id": "3", "lowNum": "03", "uprightFor": "vertical" },
+    "connection": {
+      "card": { "id": "2", "lowNum": "02", "uprightFor": "vertical" },
+      "x": 0,
+      "y": 0
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "3", "lowNum": "03", "uprightFor": "vertical" },
+          { "id": "2", "lowNum": "02", "uprightFor": "vertical" },
+          { "id": "1", "lowNum": "01", "uprightFor": "vertical" }
+        ],
+        "1": [null, { "id": "19", "lowNum": "19", "uprightFor": "horizontal" }, null]
+      }
+    }
+  },
+  {
+    "name": "extends columns when connecting vertically at the beginning",
+    "orientation": "vertical",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "3", "lowNum": "03", "uprightFor": "vertical" },
+          { "id": "2", "lowNum": "02", "uprightFor": "vertical" }
+        ],
+        "1": [{ "id": "29", "lowNum": "29", "uprightFor": "horizontal" }, null]
+      }
+    },
+    "card": { "id": "1", "lowNum": "01", "uprightFor": "vertical" },
+    "connection": {
+      "card": { "id": "2", "lowNum": "02", "uprightFor": "vertical" },
+      "x": 0,
+      "y": 1
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "3", "lowNum": "03", "uprightFor": "vertical" },
+          { "id": "2", "lowNum": "02", "uprightFor": "vertical" },
+          { "id": "1", "lowNum": "01", "uprightFor": "vertical" }
+        ],
+        "1": [{ "id": "29", "lowNum": "29", "uprightFor": "horizontal" }, null, null]
+      }
+    }
+  },
+  {
+    "name": "connects a card of a different orientation vertically, filling a blank space",
+    "orientation": "vertical",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "15", "lowNum": "15", "uprightFor": "horizontal" },
+          { "id": "05", "lowNum": "05", "uprightFor": "horizontal" },
+          null
+        ],
+        "1": [
+          null,
+          { "id": "04", "lowNum": "04", "uprightFor": "horizontal" },
+          { "id": "39", "lowNum": "39", "uprightFor": "vertical" }
+        ]
+      }
+    },
+    "card": { "id": "49", "lowNum": "49", "uprightFor": "vertical" },
+    "connection": {
+      "card": { "id": "05", "lowNum": "05", "uprightFor": "horizontal" },
+      "x": 0,
+      "y": 1
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "15", "lowNum": "15", "uprightFor": "horizontal" },
+          { "id": "05", "lowNum": "05", "uprightFor": "horizontal" },
+          { "id": "49", "lowNum": "49", "uprightFor": "vertical" }
+        ],
+        "1": [
+          null,
+          { "id": "04", "lowNum": "04", "uprightFor": "horizontal" },
+          { "id": "39", "lowNum": "39", "uprightFor": "vertical" }
+        ]
+      }
+    }
+  },
+  {
+    "name": "extends rows when connecting horizontally at the beginning",
+    "orientation": "horizontal",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [null, { "id": "3", "lowNum": "03", "uprightFor": "horizontal" }],
+        "1": [
+          { "id": "12", "lowNum": "12", "uprightFor": "horizontal" },
+          { "id": "2", "lowNum": "02", "uprightFor": "horizontal" }
+        ]
+      }
+    },
+    "card": { "id": "1", "lowNum": "01", "uprightFor": "horizontal" },
+    "connection": {
+      "card": { "id": "2", "lowNum": "02", "uprightFor": "horizontal" },
+      "x": 1,
+      "y": 1
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [null, { "id": "3", "lowNum": "03", "uprightFor": "horizontal" }],
+        "1": [
+          { "id": "12", "lowNum": "12", "uprightFor": "horizontal" },
+          { "id": "2", "lowNum": "02", "uprightFor": "horizontal" }
+        ],
+        "2": [null, { "id": "1", "lowNum": "01", "uprightFor": "horizontal" }]
+      }
+    }
+  },
+  {
+    "name": "extends rows when connecting horizontally at the end",
+    "orientation": "horizontal",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [null, { "id": "3", "lowNum": "03", "uprightFor": "horizontal" }],
+        "1": [
+          { "id": "12", "lowNum": "12", "uprightFor": "horizontal" },
+          { "id": "2", "lowNum": "02", "uprightFor": "horizontal" }
+        ]
+      }
+    },
+    "card": { "id": "4", "lowNum": "04", "uprightFor": "horizontal" },
+    "connection": {
+      "card": { "id": "3", "lowNum": "03", "uprightFor": "horizontal" },
+      "x": 0,
+      "y": 1
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [null, { "id": "4", "lowNum": "04", "uprightFor": "horizontal" }],
+        "1": [null, { "id": "3", "lowNum": "03", "uprightFor": "horizontal" }],
+        "2": [
+          { "id": "12", "lowNum": "12", "uprightFor": "horizontal" },
+          { "id": "2", "lowNum": "02", "uprightFor": "horizontal" }
+        ]
+      }
+    }
+  },
+  {
+    "name": "connects a card horizontally at an earlier x coordinate, filling a blank space",
+    "orientation": "horizontal",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "34", "lowNum": "34", "uprightFor": "vertical" },
+          { "id": "33", "lowNum": "33", "uprightFor": "vertical" },
+          null,
+          null
+        ],
+        "1": [null, { "id": "23", "lowNum": "23", "uprightFor": "vertical" }, null, null],
+        "2": [
+          null,
+          { "id": "13", "lowNum": "13", "uprightFor": "vertical" },
+          { "id": "12", "lowNum": "12", "uprightFor": "vertical" },
+          { "id": "11", "lowNum": "11", "uprightFor": "vertical" }
+        ],
+        "3": [
+          null,
+          { "id": "03", "lowNum": "03", "uprightFor": "vertical" },
+          { "id": "02", "lowNum": "02", "uprightFor": "vertical" },
+          { "id": "01", "lowNum": "01", "uprightFor": "vertical" }
+        ]
+      }
+    },
+    "card": { "id": "22", "lowNum": "22", "uprightFor": "vertical" },
+    "connection": {
+      "card": { "id": "12", "lowNum": "12", "uprightFor": "vertical" },
+      "x": 2,
+      "y": 2
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "34", "lowNum": "34", "uprightFor": "vertical" },
+          { "id": "33", "lowNum": "33", "uprightFor": "vertical" },
+          null,
+          null
+        ],
+        "1": [
+          null,
+          { "id": "23", "lowNum": "23", "uprightFor": "vertical" },
+          { "id": "22", "lowNum": "22", "uprightFor": "vertical" },
+          null
+        ],
+        "2": [
+          null,
+          { "id": "13", "lowNum": "13", "uprightFor": "vertical" },
+          { "id": "12", "lowNum": "12", "uprightFor": "vertical" },
+          { "id": "11", "lowNum": "11", "uprightFor": "vertical" }
+        ],
+        "3": [
+          null,
+          { "id": "03", "lowNum": "03", "uprightFor": "vertical" },
+          { "id": "02", "lowNum": "02", "uprightFor": "vertical" },
+          { "id": "01", "lowNum": "01", "uprightFor": "vertical" }
+        ]
+      }
+    }
+  },
+  {
+    "name": "rejects a claimed connection whose cell holds a different card",
+    "orientation": "vertical",
+    "group": {
+      "id": "1",
+      "cards": {
+        "0": [{ "id": "5", "lowNum": "05", "uprightFor": "vertical" }]
+      }
+    },
+    "card": { "id": "4", "lowNum": "04", "uprightFor": "vertical" },
+    "connection": {
+      "card": { "id": "6", "lowNum": "06", "uprightFor": "vertical" },
+      "x": 0,
+      "y": 0
+    },
+    "error": "The connecting card details are not correct"
+  },
+  {
+    "name": "rejects placement onto an occupied cell (server hardening, PHP only)",
+    "phpOnly": true,
+    "orientation": "vertical",
+    "group": {
+      "id": "1",
+      "cards": {
+        "0": [
+          { "id": "5", "lowNum": "05", "uprightFor": "vertical" },
+          { "id": "44", "lowNum": "44", "uprightFor": "vertical" }
+        ]
+      }
+    },
+    "card": { "id": "4", "lowNum": "04", "uprightFor": "vertical" },
+    "connection": {
+      "card": { "id": "5", "lowNum": "05", "uprightFor": "vertical" },
+      "x": 0,
+      "y": 0
+    },
+    "error": "The destination cell is already occupied"
+  }
+]

--- a/tests/fixtures/moves/connectGroups.json
+++ b/tests/fixtures/moves/connectGroups.json
@@ -1,0 +1,135 @@
+[
+  {
+    "name": "merges two groups vertically, higher connecting number on top",
+    "orientation": "vertical",
+    "group1": {
+      "group": {
+        "id": "1",
+        "cards": { "0": [{ "id": "5", "lowNum": "05", "uprightFor": "vertical" }] }
+      },
+      "connection": {
+        "card": { "id": "5", "lowNum": "05", "uprightFor": "vertical" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "group2": {
+      "group": {
+        "id": "2",
+        "cards": { "0": [{ "id": "4", "lowNum": "04", "uprightFor": "vertical" }] }
+      },
+      "connection": {
+        "card": { "id": "4", "lowNum": "04", "uprightFor": "vertical" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "5", "lowNum": "05", "uprightFor": "vertical" },
+          { "id": "4", "lowNum": "04", "uprightFor": "vertical" }
+        ]
+      }
+    }
+  },
+  {
+    "name": "merges two groups horizontally, lesser connecting number at greater x in the data",
+    "orientation": "horizontal",
+    "group1": {
+      "group": {
+        "id": "1",
+        "cards": { "0": [{ "id": "5", "lowNum": "05", "uprightFor": "horizontal" }] }
+      },
+      "connection": {
+        "card": { "id": "5", "lowNum": "05", "uprightFor": "horizontal" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "group2": {
+      "group": {
+        "id": "2",
+        "cards": { "0": [{ "id": "4", "lowNum": "04", "uprightFor": "horizontal" }] }
+      },
+      "connection": {
+        "card": { "id": "4", "lowNum": "04", "uprightFor": "horizontal" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "expected": {
+      "id": "2",
+      "cards": {
+        "0": [{ "id": "5", "lowNum": "05", "uprightFor": "horizontal" }],
+        "1": [{ "id": "4", "lowNum": "04", "uprightFor": "horizontal" }]
+      }
+    }
+  },
+  {
+    "name": "rejects a merge whose claimed connection cell holds a different card",
+    "orientation": "vertical",
+    "group1": {
+      "group": {
+        "id": "1",
+        "cards": { "0": [{ "id": "5", "lowNum": "05", "uprightFor": "vertical" }] }
+      },
+      "connection": {
+        "card": { "id": "9", "lowNum": "09", "uprightFor": "vertical" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "group2": {
+      "group": {
+        "id": "2",
+        "cards": { "0": [{ "id": "4", "lowNum": "04", "uprightFor": "vertical" }] }
+      },
+      "connection": {
+        "card": { "id": "4", "lowNum": "04", "uprightFor": "vertical" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "error": "The connecting card details are not correct"
+  },
+  {
+    "name": "rejects a merge where the groups would overlap (server hardening, PHP only)",
+    "phpOnly": true,
+    "orientation": "vertical",
+    "group1": {
+      "group": {
+        "id": "1",
+        "cards": {
+          "0": [
+            { "id": "5", "lowNum": "05", "uprightFor": "vertical" },
+            { "id": "3", "lowNum": "03", "uprightFor": "vertical" }
+          ]
+        }
+      },
+      "connection": {
+        "card": { "id": "5", "lowNum": "05", "uprightFor": "vertical" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "group2": {
+      "group": {
+        "id": "2",
+        "cards": {
+          "0": [
+            { "id": "6", "lowNum": "06", "uprightFor": "vertical" },
+            { "id": "4", "lowNum": "04", "uprightFor": "vertical" }
+          ]
+        }
+      },
+      "connection": {
+        "card": { "id": "6", "lowNum": "06", "uprightFor": "vertical" },
+        "x": 0,
+        "y": 0
+      }
+    },
+    "error": "The groups overlap and cannot be connected there"
+  }
+]

--- a/tests/fixtures/moves/getConnectingNumbers.json
+++ b/tests/fixtures/moves/getConnectingNumbers.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "returns the numbers one lower and one higher, zero-padded",
+    "num": "05",
+    "expected": ["04", "06"]
+  },
+  {
+    "name": "pads across the tens boundary",
+    "num": "10",
+    "expected": ["09", "11"]
+  },
+  {
+    "name": "rejects strings that are not exactly 2 characters",
+    "num": "1",
+    "error": "the number string should be exactly 2 characters long"
+  },
+  {
+    "name": "rejects numbers above 98",
+    "num": "99",
+    "error": "the number must be between 01 and 98"
+  },
+  {
+    "name": "rejects 00",
+    "num": "00",
+    "error": "the number must be between 01 and 98"
+  }
+]

--- a/tests/fixtures/moves/getConnection.json
+++ b/tests/fixtures/moves/getConnection.json
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "finds a connection using the orientation-adjusted shown number",
+    "card": { "id": "49", "lowNum": "49", "uprightFor": "vertical" },
+    "orientation": "vertical",
+    "group": {
+      "id": "2",
+      "cards": {
+        "0": [
+          { "id": "15", "lowNum": "15", "uprightFor": "horizontal" },
+          { "id": "05", "lowNum": "05", "uprightFor": "horizontal" }
+        ]
+      }
+    },
+    "expected": {
+      "card": { "id": "05", "lowNum": "05", "uprightFor": "horizontal" },
+      "x": 0,
+      "y": 1
+    }
+  },
+  {
+    "name": "throws when no card in the group connects",
+    "card": { "id": "70", "lowNum": "07", "uprightFor": "vertical" },
+    "orientation": "vertical",
+    "group": {
+      "id": "1",
+      "cards": {
+        "0": [{ "id": "01", "lowNum": "01", "uprightFor": "vertical" }]
+      }
+    },
+    "error": "the card is not a valid option to connect to the group"
+  }
+]

--- a/tethergame.action.php
+++ b/tethergame.action.php
@@ -31,10 +31,10 @@ class action_tethergame extends APP_GameAction
 	{
 		self::setAjaxMode();
 
-		/** @var string $gameStateJSON */
-		$gameStateJSON = self::getArg('gameStateJSON', AT_json, true);
+		/** @var string $moves */
+		$moves = self::getArg('moves', AT_json, true);
 
-		$this->game->actConnectAstronauts( $gameStateJSON );
+		$this->game->actConnectAstronauts( $moves );
 		self::ajaxResponse();
 	}
 

--- a/tethergame.js
+++ b/tethergame.js
@@ -446,6 +446,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
             _this.playerDirection = null;
             _this.cardMap = {};
             _this.playableCardNumbers = [];
+            _this.turnMoves = [];
             _this.setupNotifications = function () {
                 console.log('notifications subscriptions setup');
                 dojo.subscribe('cardSetAdrift', _this, 'notif_cardSetAdrift');
@@ -464,7 +465,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                 dojo.subscribe('updateGameState', _this, 'notif_updateGameState');
                 _this.notifqueue.setSynchronous('updateGameState', 500);
             };
-            console.log('tethergame constructor');
+            console.log('tethergame constructor is working');
             return _this;
         }
         TetherGame.prototype.createCardElement = function (_a) {
@@ -1033,6 +1034,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
             this.updateBoardUI();
         };
         TetherGame.prototype.cancelConnectAstronautsAction = function () {
+            this.turnMoves = [];
             this.clearSelectedCards();
             this.clearSelectableCards();
             this.clearEventListeners();
@@ -1067,6 +1069,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                 }
             });
             if (this.clientState.status === 'choosingAction') {
+                this.turnMoves = [];
                 this.clientState = { status: 'connectingAstronautsInitial' };
                 this.setClientState('client_connectAstronautInitial', {
                     descriptionmyturn: _('${you} must select an astronaut from your hand to begin connecting.'),
@@ -1187,6 +1190,20 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                 },
                 orientation: this.playerDirection,
             });
+            this.turnMoves.push({
+                action: 'mergeGroups',
+                otherGroupId: groupToConnectId,
+                currentConnection: {
+                    cardId: currentGroupConnectionPoint.card.id,
+                    x: currentGroupConnectionPoint.x,
+                    y: currentGroupConnectionPoint.y,
+                },
+                otherConnection: {
+                    cardId: cardToConnect.id,
+                    x: parseInt(x, 10),
+                    y: parseInt(y, 10),
+                },
+            });
             delete this.gameStateCurrent.board[groupToConnectId];
             this.gameStateCurrent.board[combinedGroup.id] = combinedGroup;
             this.currentGroup = combinedGroup.id;
@@ -1262,6 +1279,7 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                 console.log('first card played, the new group ID is', newGroupId);
                 this.currentGroup = newGroupId;
                 this.gameStateCurrent.board[this.currentGroup] = this.createGroupFromCard(card, newGroupId);
+                this.turnMoves.push({ action: 'startGroup', cardId: id, from: from, flipped: flipped });
                 this.updateBoardUI();
             }
             else {
@@ -1279,11 +1297,23 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
                     lowNum: card.number,
                     uprightFor: uprightFor,
                 };
+                var connection = (0, getConnection_1.getConnection)(cardToConnect, group, this.playerDirection);
                 (0, connectCardToGroup_1.connectCardToGroup)({
                     group: group,
                     card: cardToConnect,
-                    connection: (0, getConnection_1.getConnection)(cardToConnect, group, this.playerDirection),
+                    connection: connection,
                     orientation: this.playerDirection,
+                });
+                this.turnMoves.push({
+                    action: 'placeCard',
+                    cardId: id,
+                    from: from,
+                    flipped: flipped,
+                    connection: {
+                        cardId: connection.card.id,
+                        x: connection.x,
+                        y: connection.y,
+                    },
                 });
                 this.updateBoardUI();
             }
@@ -1292,8 +1322,9 @@ define("bgagame/tethergame", ["require", "exports", "ebg/core/gamegui", "connect
         };
         TetherGame.prototype.finishConnectingAstronauts = function () {
             this.bgaPerformAction('actConnectAstronauts', {
-                gameStateJSON: JSON.stringify(this.gameStateCurrent),
+                moves: JSON.stringify(this.turnMoves),
             });
+            this.turnMoves = [];
             this.clearSelectableCards();
         };
         TetherGame.prototype.notif_cardSetAdrift = function (notif) {


### PR DESCRIPTION
Resolves #26 

The client now sends a minimal ordered move list (startGroup / placeCard / mergeGroups) instead of the full computed board state. The server replays the moves against database state with PHP ports of the client rule functions (BoardLogic), enforces turn structure and card ownership (MoveValidator), and writes the board it computed itself. Illegal moves throw BgaUserException, failing the action atomically instead of being swallowed silently. actSetAdrift is validated the same way.

- Shared JSON fixtures in tests/fixtures/moves are run by both the uvu specs and PHPUnit so the TS and PHP rule implementations cannot drift
- Server is stricter than the client in two spots the TS mishandles silently: occupied destination cells and overlapping merges reject
- Guard stDrawAtEndOfTurn against an empty deck (previously fataled)
- Fix stale GroupLogicTest assertion ('number' -> 'id')
- Add CONTEXT.md glossary, ADR 0001, and a design note for a future choose-your-connection-spot UI